### PR TITLE
Ray casting goal selection

### DIFF
--- a/src/bringup/README.md
+++ b/src/bringup/README.md
@@ -196,15 +196,14 @@ ros2 launch bringup navigation.launch.py mode:=<mode> [course:=<course>]
 - `odom/local` (`nav_msgs/Odometry`) - Odometry from localization
 
 ### Published Topics
-- `goal` (`geometry_msgs/PointStamped`) - Goal for path planning (`autonav` only)
-- `gps_waypoint` (`geometry_msgs/PointStamped`) - Current GPS waypoint target (`autonav` only)
+- `waypoint` (`geometry_msgs/PointStamped`) - Current GPS waypoint target, latched (`autonav` only)
 - `nav_cmd_vel` (`geometry_msgs/Twist`) - Velocity command consumed by twist_mux
 - `recovery_cmd_vel` (`geometry_msgs/Twist`) - Recovery velocity command consumed by twist_mux (all modes)
 
 ### Service Clients
-- `fromLL` (`robot_localization/FromLL`) - Converts GPS coordinates to map-frame points; called at startup by
-autonav_goal_selection (`autonav` only)
+- `fromLL` (`robot_localization/FromLL`) - Converts GPS coordinates to map-frame points; called at startup by autonav_goal_selection (`autonav` only)
 - `state/set_recovery` (`std_srvs/SetBool`) - Signals recovery state transitions (all modes)
+- `state/set_no_mans_land` (`std_srvs/SetBool`) - Signals no-man's-land transitions when a flagged waypoint is reached (`autonav` only)
 
 
 ## teleop.launch.py

--- a/src/bringup/courses/default/gps.json
+++ b/src/bringup/courses/default/gps.json
@@ -6,8 +6,8 @@
     },
     "waypoints": [
         {"latitude": 42.29478329, "longitude": -83.70810902},
-        {"latitude": 42.29483487, "longitude": -83.70780593},
-        {"latitude": 42.29462457, "longitude": -83.70792126},
-        {"latitude": 42.294621, "longitude": -83.708112}
+        {"x": 25.2, "y": 23.8, "no_mans_land": true},
+        {"latitude": 42.29462457, "longitude": -83.70792126, "no_mans_land": true},
+        {"x": 0.0, "y": 0.0}
     ]
 }

--- a/src/bringup/launch/navigation.launch.py
+++ b/src/bringup/launch/navigation.launch.py
@@ -53,9 +53,13 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         remappings=[
             ("occupancy_grid", "occupancy_grid/transformed"),
             ("odom", "odom/local"),
+            ("state", "state"),
             ("fromLL", "fromLL"),
+            ("state/set_recovery", "state/set_recovery"),
+            ("state/set_no_mans_land", "state/set_no_mans_land"),
             ("goal", "goal"),
-            ("gps_waypoint", "gps_waypoint"),
+            ("waypoint", "waypoint"),
+            ("goal_selection_debug", "goal_selection_debug"),
         ],
     )
 

--- a/src/bringup/launch/navigation.launch.py
+++ b/src/bringup/launch/navigation.launch.py
@@ -1,6 +1,8 @@
 from bringup.launch_utils import MODES, Mode, bringup_share, format_mode_description, load_frames
 from launch import LaunchDescription, LaunchDescriptionEntity
-from launch.actions import DeclareLaunchArgument, OpaqueFunction
+from launch.actions import DeclareLaunchArgument, EmitEvent, OpaqueFunction, RegisterEventHandler
+from launch.event_handlers import OnProcessExit
+from launch.events import Shutdown
 from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
 from typing_extensions import assert_never
@@ -85,6 +87,13 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         output="screen",
     )
 
+    shutdown_on_completion = RegisterEventHandler(
+        OnProcessExit(
+            target_action=autonav_goal_selection_node,
+            on_exit=[EmitEvent(event=Shutdown())],
+        )
+    )
+
     match mode:
         case "autonav":
             return [
@@ -93,6 +102,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
                 path_planning_node,
                 autonav_goal_selection_node,
                 recovery_behavior_node,
+                shutdown_on_completion,
             ]
         case "self_drive" | "nav_test":
             return [occupancy_grid_transform_node, path_tracking_node, path_planning_node, recovery_behavior_node]

--- a/src/core/utils/README.md
+++ b/src/core/utils/README.md
@@ -121,6 +121,7 @@ Wraps a yaw angle in radians. Angle is automatically wrapped to `[-π, π]` and 
 | `distance(other)` | Distance to another `Point2d` |
 | `to_ros()` | Convert to `geometry_msgs/Point` |
 | `from_ros(point)` | Construct from a `geometry_msgs/Point` |
+| `unit(vector)` | Construct a unit vector from a 2D direction |
 
 ### `Pose2d`
 2D pose (position + rotation) with world/local frame transforms and ROS interop.

--- a/src/core/utils/README.md
+++ b/src/core/utils/README.md
@@ -121,7 +121,7 @@ Wraps a yaw angle in radians. Angle is automatically wrapped to `[-π, π]` and 
 | `distance(other)` | Distance to another `Point2d` |
 | `to_ros()` | Convert to `geometry_msgs/Point` |
 | `from_ros(point)` | Construct from a `geometry_msgs/Point` |
-| `unit(vector)` | Construct a unit vector from a 2D direction |
+| `unit(vector)` | Construct a Point2d 1 unit away from the origin in the direction of rotation |
 
 ### `Pose2d`
 2D pose (position + rotation) with world/local frame transforms and ROS interop.

--- a/src/core/utils/utils/geometry.py
+++ b/src/core/utils/utils/geometry.py
@@ -212,7 +212,7 @@ class Point2d:
 
     @classmethod
     def unit(cls, rotation: Rotation2d) -> Point2d:
-        """Return the unit vector pointing in the given direction.
+        """Return the Point2d 1 unit away from the origin in the direction of rotation.
 
         Args:
             rotation: Direction to point toward.

--- a/src/core/utils/utils/geometry.py
+++ b/src/core/utils/utils/geometry.py
@@ -211,6 +211,18 @@ class Point2d:
         return Point(x=self.x, y=self.y, z=0.0)
 
     @classmethod
+    def unit(cls, rotation: Rotation2d) -> Point2d:
+        """Return the unit vector pointing in the given direction.
+
+        Args:
+            rotation: Direction to point toward.
+
+        Returns:
+            Point2d with x=cos(rotation.angle), y=sin(rotation.angle).
+        """
+        return cls(x=rotation.cos, y=rotation.sin)
+
+    @classmethod
     def from_ros(cls, point: Point) -> Point2d:
         """Construct from a ROS Point, discarding z.
 

--- a/src/navigation/autonav_goal_selection/README.md
+++ b/src/navigation/autonav_goal_selection/README.md
@@ -1,39 +1,113 @@
 # autonav_goal_selection
-GPS waypoint following with local goal selection for autonomous navigation.
+Map waypoint following with local goal selection for autonomous navigation.
 
-Loads a list of GPS waypoints from a JSON file, converts them to map-frame coordinates via the `fromLL` service, and 
-selects a local goal from the occupancy grid on a timer. The goal is chosen by scoring every drivable cell with a 
-heuristic. Waypoints are advanced automatically as the robot reaches them.
+Loads a list of map-frame waypoints from a JSON file and, on a timer, selects a local goal by ray-casting across the 
+robot's forward arc through the occupancy grid. Each ray is scored by its free length weighted by a momentum alignment 
+factor; the highest-scoring ray's endpoint (pulled back by a safety margin) is published as the goal. A momentum angle 
+is tracked across ticks via EMA and biases scoring toward directional consistency. When the robot is within 
+`waypoint_approach_radius_m` of the current waypoint, ray-casting is bypassed and the waypoint itself is published 
+directly. Waypoints advance automatically as they are reached.
+
+## Waypoints File Format
+```json
+{
+    "waypoints": [
+        {"x": 5.0, "y": 0.0},
+        {"latitude": 42.2946, "longitude": -83.7238},
+        {"x": 10.0, "y": 5.0, "no_mans_land": true}
+    ]
+}
+```
+Each waypoint is either map-frame `x`/`y` (meters) or GPS `latitude`/`longitude` (converted via `fromLL` at
+startup). Setting `no_mans_land: true` toggles no-man's-land state when that waypoint is reached.
+
+## State Machine Integration
+This node both reads and writes state via the `state` topic and two service clients.
+
+**Recovery** is triggered when all rays are shorter than `min_goal_progress_m` (the robot is surrounded by obstacles). 
+The node calls `state/set_recovery true`, resets momentum, and stops publishing goals. The external state machine is 
+responsible for driving the robot out of the stuck situation and calling `state/set_recovery false` when done.
+
+**No-man's land** is toggled each time a waypoint flagged `no_mans_land: true` is reached. The node calls 
+`state/set_no_mans_land` with the new boolean value and logs the transition. No-man's land waypoints act as region 
+boundary markers: the first one entering a region sets the flag true, the next one exiting sets it false.
 
 ## Subscribed Topics
-- `odom` (`nav_msgs/msg/Odometry`) — Robot pose in the world frame, used for waypoint advancement and goal scoring
-- `occupancy_grid` (`nav_msgs/msg/OccupancyGrid`) — Occupancy grid used to find drivable goal candidates
+| Topic | Type | Description |
+|---|---|---|
+| `odom` | `nav_msgs/msg/Odometry` | Robot pose in the world frame |
+| `occupancy_grid` | `nav_msgs/msg/OccupancyGrid` | Local occupancy grid rays are cast through |
+| `state` | `std_msgs/msg/String` | State machine state; `"recovery"` suppresses goal publishing |
 
 ## Published Topics
-- `goal` (`geometry_msgs/msg/PointStamped`) — Selected local goal in the world frame, published at `goal_publish_period_s`
-- `gps_waypoint` (`geometry_msgs/msg/PointStamped`) — Current GPS waypoint converted to map-frame coordinates; latched
-
-The `gps_waypoint` topic uses a non-default QoS profile:
-| Setting | Value | Effect |
+| Topic | Type | Description |
 |---|---|---|
-| Durability | `TRANSIENT_LOCAL` | Late-joining subscribers immediately receive the current waypoint |
-| History | `KEEP_LAST` (depth 1) | Only the most recent waypoint is retained |
+| `goal` | `geometry_msgs/msg/PointStamped` | Selected local goal in the world frame |
+| `waypoint` | `geometry_msgs/msg/PointStamped` | Current map-frame waypoint (latched) |
+| `goal_selection_debug` | `visualization_msgs/msg/MarkerArray` | Ray visualization; only published when `publish_debug` is true |
 
-Subscribers to `gps_waypoint` **must use a compatible QoS** (`TRANSIENT_LOCAL`) or they will not receive the latched
-message on connect. In code, use `utils.qos.LATCHED`. In RViz, set the topic's **Durability Policy** to `Transient Local`.
+The `waypoint` topic uses a latched QoS profile (`TRANSIENT_LOCAL`, depth 1). Late-joining subscribers receive the
+current waypoint immediately on connect. Subscribers **must** use a compatible QoS (`TRANSIENT_LOCAL`) or they will
+not receive the message. In code, use `utils.qos.LATCHED`. In RViz, set **Durability Policy** to `Transient Local`.
 
-## Services
-- `fromLL` (`robot_localization/srv/FromLL`) — Called at startup to convert each GPS waypoint to a map-frame point
+## Service Clients
+| Service | Type | Description |
+|---|---|---|
+| `fromLL` | `robot_localization/srv/FromLL` | Converts GPS waypoints to map-frame coordinates at startup |
+| `state/set_recovery` | `std_srvs/srv/SetBool` | Triggers recovery when no drivable goal is found |
+| `state/set_no_mans_land` | `std_srvs/srv/SetBool` | Toggles no-man's-land state when a flagged waypoint is reached |
 
-## Config Parameters
+## Config Parameters (`AutonavGoalSelectionConfig`)
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `goal_selection_params` | `GoalSelectionParams` | required | Parameters for the goal selection heuristic (see below) |
-| `waypoints_file_path` | `Path` | required | Path to a JSON file containing the list of GPS waypoints to navigate |
-| `goal_publish_period_s` | `float` | `5.0` | How often (s) to publish a new local goal |
-| `waypoint_reached_threshold` | `float` | `1.0` | Distance (m) within which a waypoint is considered reached |
-| `map_frame_id` | `str` | `map` | TF frame ID for the map coordinate frame |
-| `world_frame_id` | `str` | `odom` | TF frame ID for the world coordinate frame |
+| `goal_selection_params` | `GoalSelectionParams` | required | Ray-cast goal selection parameters (see below) |
+| `waypoints_file_path` | `Path` | required | Path to the JSON waypoints file |
+| `goal_publish_period_s` | `float` | `0.25` | Timer period (s) for goal selection and publishing |
+| `waypoint_reached_threshold_m` | `float` | `1.0` | Distance (m) within which a waypoint is considered reached |
+| `waypoint_approach_radius_m` | `float` | `5.0` | Distance (m) from the waypoint within which ray-casting is bypassed and the waypoint is published directly |
+| `map_frame_id` | `str` | `"map"` | TF frame for map-frame waypoint coordinates |
+| `world_frame_id` | `str` | `"odom"` | TF frame for the world/robot pose coordinates |
+| `publish_debug` | `bool` | `true` | When true, publish the `goal_selection_debug` MarkerArray |
 
-### Goal Selection Parameters (`goal_selection_params`)
-(Currently empty)
+### Goal Selection Parameters (`GoalSelectionParams`)
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `momentum` | `MomentumParams` | required | Momentum behavior parameters (see below) |
+| `arc_angle_rad` | `float` | `π` | Full angular width of the forward arc; rays span symmetrically around the robot's heading |
+| `ray_interval_rad` | `float` | `1.25°` | Angular spacing between rays; num_rays = `int(arc / interval) + 1` |
+| `step_size_m` | `float` | `0.05` | Step size when walking each ray; should be ≈ grid resolution |
+| `min_goal_progress_m` | `float` | `0.9` | Minimum ray length for a goal to be published; below this, no goal is published and recovery is triggered |
+| `safety_margin_m` | `float` | `0.9` | Distance (m) the goal endpoint is pulled back from where the ray terminated |
+| `neighbor_smoothing_window` | `int` | `2` | Number of neighbors per side averaged into each ray's score before picking |
+| `max_unknown_forward_m` | `float` | `5.0` | How far forward unknown cells are treated as drivable |
+| `max_unknown_sideways_m` | `float` | `2.5` | How far sideways unknown cells are treated as drivable |
+
+### Momentum Parameters (`MomentumParams`)
+Each tick the highest-scoring ray's angle is EMA-smoothed into a stored momentum angle. Scoring multiplies each ray's 
+free length by a momentum factor in `[0, 1]` that rewards alignment with the momentum direction and scales down when the 
+momentum-aligned ray itself is short (obstacle ahead).
+
+Momentum factor formula, where $\theta$ is the angle between the ray and the momentum direction, $L_m$ is the free 
+length of the momentum-aligned ray, and $\tau$, $f$, $g_o$, $g_a$ are `obstacle_threshold_m`, `alignment_floor`, 
+`obstacle_gain`, `alignment_gain` respectively:
+
+$$s = \min\!\left(1,\, \frac{L_m}{\tau}\right)^{g_o}$$
+
+$$\text{factor} = (1 - s) + s \left[ f + (1 - f) \left(\frac{1 + \cos\theta}{2}\right)^{g_a} \right]$$
+
+When $s = 1$ (momentum direction is clear), factor equals the alignment term. When $s = 0$ (momentum direction is 
+blocked), factor equals 1 and all rays score equally on direction, letting the longest ray win.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `alignment_gain` | `float` | `2.0` | Sharpness of the directional penalty. `0` disables momentum bias; higher values penalize off-axis rays more aggressively |
+| `alignment_floor` | `float` | `0.1` | Minimum alignment factor regardless of angle; prevents any ray from scoring zero due to direction alone |
+| `obstacle_threshold_m` | `float` | `4.0` | Momentum ray length (m) below which momentum weight begins scaling down |
+| `obstacle_gain` | `float` | `2.0` | Shape of the obstacle scaling curve: `<1` drops quickly, `1` is linear, `>1` stays near 1 until very close to 0 |
+| `ema_alpha` | `float` | `0.1` | EMA smoothing factor for the momentum angle. Lower = more stable; higher = reacts faster to direction changes |
+
+## Debug Visualization
+With `publish_debug: true`, subscribe to `goal_selection_debug` in RViz (MarkerArray display). You will see:
+- Thin lines for all rays, colored red→green by normalized score
+- A thick yellow line for the chosen (highest-scoring) ray
+- A thick blue line for the momentum-aligned ray

--- a/src/navigation/autonav_goal_selection/README.md
+++ b/src/navigation/autonav_goal_selection/README.md
@@ -66,7 +66,7 @@ Low `ema_alpha` (default 0.1) means momentum changes slowly; high values make it
 ### Waypoint approach
 When the robot is within `waypoint_approach_radius_m` (default 5 m) of the current waypoint, ray casting is skipped
 entirely and the waypoint itself is published as the goal. This ensures the robot reaches waypoints precisely rather
-than stopping short. Once within `waypoint_reached_threshold_m` (default 1 m), the waypoint is marked reached and the
+than stopping short. Once within `waypoint_reached_threshold_m` (default 1.5m), the waypoint is marked reached and the
 next one becomes active.
 
 ## Waypoints File Format
@@ -124,7 +124,7 @@ not receive the message. In code, use `utils.qos.LATCHED`. In RViz, set **Durabi
 | `goal_selection_params` | `GoalSelectionParams` | required | Ray-cast goal selection parameters (see below) |
 | `waypoints_file_path` | `Path` | required | Path to the JSON waypoints file |
 | `goal_publish_period_s` | `float` | `0.25` | Timer period (s) for goal selection and publishing |
-| `waypoint_reached_threshold_m` | `float` | `1.0` | Distance (m) within which a waypoint is considered reached |
+| `waypoint_reached_threshold_m` | `float` | `1.5` | Distance (m) within which a waypoint is considered reached |
 | `waypoint_approach_radius_m` | `float` | `5.0` | Distance (m) from the waypoint within which ray-casting is bypassed and the waypoint is published directly |
 | `map_frame_id` | `str` | `"map"` | TF frame for map-frame waypoint coordinates |
 | `world_frame_id` | `str` | `"odom"` | TF frame for the world/robot pose coordinates |

--- a/src/navigation/autonav_goal_selection/README.md
+++ b/src/navigation/autonav_goal_selection/README.md
@@ -1,12 +1,73 @@
 # autonav_goal_selection
 Map waypoint following with local goal selection for autonomous navigation.
 
-Loads a list of map-frame waypoints from a JSON file and, on a timer, selects a local goal by ray-casting across the 
-robot's forward arc through the occupancy grid. Each ray is scored by its free length weighted by a momentum alignment 
-factor; the highest-scoring ray's endpoint (pulled back by a safety margin) is published as the goal. A momentum angle 
-is tracked across ticks via EMA and biases scoring toward directional consistency. When the robot is within 
-`waypoint_approach_radius_m` of the current waypoint, ray-casting is bypassed and the waypoint itself is published 
-directly. Waypoints advance automatically as they are reached.
+## How it works
+
+### The big picture
+The robot is given a list of coarse GPS/map waypoints (think: "go to this field corner, then that one"). The waypoints
+are far apart and don't account for obstacles between them. This node's job is to bridge that gap: every publish period 
+it picks a local goal a few meters ahead that keeps the robot moving toward the current waypoint while staying in 
+drivable space.
+
+### Step 1 — Ray casting
+Each tick, the node shoots a fan of rays outward from the robot's current position. The fan spans `arc_angle_rad`
+(default 180°) centered on the robot's heading, with rays spaced `ray_interval_rad` (default ~1.25°) apart.
+
+Each ray is walked step by step (`step_size_m`, default 5 cm ≈ grid resolution) until it hits either:
+- an **occupied cell** (obstacle), or
+- an **unknown cell** too far outside the robot's forward path (unknown cells within `max_unknown_forward_m` forward and
+  `max_unknown_sideways_m` sideways are treated as drivable, since the area right under the robot is blocked and marked
+  as unknown even though it is drivable)
+
+The ray's **length** is how far it traveled before stopping. A longer ray means more open space in that direction.
+
+### Step 2 — Scoring
+Each ray gets a score:
+
+```
+score = ray_length * momentum_factor
+```
+
+**`ray_length`** rewards pointing into open space.
+
+**`momentum_factor`** is a value in [0, 1] that rewards pointing in roughly the same direction the robot has been going. 
+It exists to prevent the robot from oscillating. Without it, a small asymmetry in the occupancy grid could flip the 
+chosen direction every tick, causing the robot to wiggle rather than drive straight.
+
+The momentum factor has two parts that interact:
+- **Alignment term**: how well this ray aligns with the current momentum angle. Rays pointing along momentum score close 
+  to 1; rays pointing sideways or backward score closer to `alignment_floor` (default 0.1). The sharpness of this 
+  penalty is controlled by `alignment_gain`.
+- **Obstacle scale**: if the momentum aligned ray itself is short (something is blocking the direction the robot has
+  been going), the alignment penalty is relaxed so that longer escape route rays can win. This kicks in below
+  `obstacle_threshold_m` and fades to zero (all rays equally weighted by length) as the momentum ray approaches zero.
+
+After scoring, each ray's score is **neighbor smoothed** by averaging it with its `neighbor_smoothing_window` adjacent
+rays. This prevents a single unusually long gap in the occupancy grid from dominating, and makes the chosen direction
+more stable.
+
+### Step 3 — Choosing and publishing the goal
+The highest scoring ray wins. The goal point is placed along that ray at `ray_length - safety_margin_m` from the robot 
+(pulling back from the termination point keeps the goal away from the obstacle edge).
+
+If the winning ray is shorter than `min_goal_progress_m`, the robot is considered stuck. No goal is published and we 
+trigger recovery
+
+### Step 4 — Updating momentum
+After choosing a direction, the stored **momentum angle** is nudged toward the chosen ray's angle using an exponential
+moving average (EMA):
+
+```
+momentum_angle += ema_alpha * (chosen_angle − momentum_angle)
+```
+
+Low `ema_alpha` (default 0.1) means momentum changes slowly; high values make it respond faster to sharp turns.
+
+### Waypoint approach
+When the robot is within `waypoint_approach_radius_m` (default 5 m) of the current waypoint, ray casting is skipped
+entirely and the waypoint itself is published as the goal. This ensures the robot reaches waypoints precisely rather
+than stopping short. Once within `waypoint_reached_threshold_m` (default 1 m), the waypoint is marked reached and the
+next one becomes active.
 
 ## Waypoints File Format
 ```json
@@ -18,8 +79,8 @@ directly. Waypoints advance automatically as they are reached.
     ]
 }
 ```
-Each waypoint is either map-frame `x`/`y` (meters) or GPS `latitude`/`longitude` (converted via `fromLL` at
-startup). Setting `no_mans_land: true` toggles no-man's-land state when that waypoint is reached.
+Each waypoint is either map frame `x`/`y` (meters) or GPS `latitude`/`longitude` (converted via `fromLL` at
+startup). Setting `no_mans_land: true` toggles no man's land state when that waypoint is reached.
 
 ## State Machine Integration
 This node both reads and writes state via the `state` topic and two service clients.
@@ -29,7 +90,7 @@ The node calls `state/set_recovery true`, resets momentum, and stops publishing 
 responsible for driving the robot out of the stuck situation and calling `state/set_recovery false` when done.
 
 **No-man's land** is toggled each time a waypoint flagged `no_mans_land: true` is reached. The node calls 
-`state/set_no_mans_land` with the new boolean value and logs the transition. No-man's land waypoints act as region 
+`state/set_no_mans_land` with the new boolean value and logs the transition. No man's land waypoints act as region 
 boundary markers: the first one entering a region sets the flag true, the next one exiting sets it false.
 
 ## Subscribed Topics

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -147,7 +147,9 @@ class AutonavGoalSelection(Node):
 
         if self.current_waypoint_index >= len(self.waypoints):
             self.get_logger().info("Final waypoint reached, stopping navigation")
-            return
+            # We don't call rclpy.shutdown() here because it causes a deadlock in humble
+            # https://github.com/ros2/rclpy/issues/1646
+            raise SystemExit(1) from None
 
         self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
         self.publish_gps_waypoint()

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -1,4 +1,5 @@
 import json
+from dataclasses import dataclass
 
 import rclpy
 import tf2_geometry_msgs  # noqa: F401 — registers PointStamped transform
@@ -6,16 +7,25 @@ import tf2_ros
 import utils.config
 import utils.qos
 from geographic_msgs.msg import GeoPoint
-from geometry_msgs.msg import PointStamped
+from geometry_msgs.msg import PointStamped, Vector3
 from nav_msgs.msg import OccupancyGrid, Odometry
 from rclpy.node import Node
 from robot_localization.srv import FromLL
-from std_msgs.msg import Header
+from std_msgs.msg import ColorRGBA, Header, String
+from std_srvs.srv import SetBool
+from tf2_ros import TransformException
 from utils.geometry import Point2d, Pose2d
 from utils.world_occupancy_grid import WorldOccupancyGrid
+from visualization_msgs.msg import Marker, MarkerArray
 
 from .autonav_goal_selection_config import AutonavGoalSelectionConfig
-from .autonav_goal_selection_impl import select_goal
+from .autonav_goal_selection_impl import GoalSelector
+
+
+@dataclass(frozen=True)
+class Waypoint:
+    point: Point2d
+    no_mans_land: bool = False
 
 
 class AutonavGoalSelection(Node):
@@ -26,26 +36,29 @@ class AutonavGoalSelection(Node):
 
         self.robot_pose: Pose2d | None = None
         self.grid: WorldOccupancyGrid | None = None
+        self.goal_selector = GoalSelector(self.config.goal_selection_params)
+        self.in_no_mans_land: bool = False
+        self.in_recovery: bool = False
+
+        self.waypoints: list[Waypoint] = self.load_waypoints()
+        self.current_waypoint_index = 0
 
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
 
-        self.from_ll_client = self.create_client(FromLL, "fromLL")
-        self.get_logger().info("Waiting for fromLL service...")
-        self.from_ll_client.wait_for_service()
-        self.get_logger().info("fromLL service available.")
-
-        self.waypoints: list[Point2d] = [self.convert_to_map_point(waypoint) for waypoint in self.load_waypoints()]
-        self.current_waypoint_index = 0
+        self.set_recovery_client = self.create_client(SetBool, "state/set_recovery")
+        self.set_no_mans_land_client = self.create_client(SetBool, "state/set_no_mans_land")
 
         self.create_subscription(Odometry, "odom", self.odom_callback, 10)
         self.create_subscription(OccupancyGrid, "occupancy_grid", self.occupancy_grid_callback, 10)
+        self.create_subscription(String, "state", self.state_callback, utils.qos.LATCHED)
 
         self.goal_publisher = self.create_publisher(PointStamped, "goal", 10)
-
-        self.gps_waypoint_publisher = self.create_publisher(PointStamped, "gps_waypoint", utils.qos.LATCHED)
+        self.waypoint_publisher = self.create_publisher(PointStamped, "waypoint", utils.qos.LATCHED)
+        self.debug_publisher = self.create_publisher(MarkerArray, "goal_selection_debug", 10)
 
         self.create_timer(self.config.goal_publish_period_s, self.publish_goal)
+
         self.publish_gps_waypoint()
 
     def odom_callback(self, msg: Odometry) -> None:
@@ -67,35 +80,47 @@ class AutonavGoalSelection(Node):
 
         self.grid = WorldOccupancyGrid(msg)
 
-    def load_waypoints(self) -> list[GeoPoint]:
+    def state_callback(self, msg: String) -> None:
+        self.in_recovery = msg.data == "recovery"
+
+    def load_waypoints(self) -> list[Waypoint]:
         with open(self.config.waypoints_file_path) as f:
             data = json.load(f)
 
-        return [
-            GeoPoint(latitude=waypoint["latitude"], longitude=waypoint["longitude"], altitude=0.0)
-            for waypoint in data["waypoints"]
-        ]
+        from_ll_client = self.create_client(FromLL, "fromLL")
 
-    def convert_to_map_point(self, waypoint: GeoPoint) -> Point2d:
-        request = FromLL.Request(ll_point=waypoint)
-        future = self.from_ll_client.call_async(request)
-        rclpy.spin_until_future_complete(self, future)
-        return Point2d.from_ros(future.result().map_point)
+        self.get_logger().info("Waiting for fromLL service...")
+        from_ll_client.wait_for_service()
+        self.get_logger().info("fromLL service available, loading waypoints")
+
+        waypoints = []
+        for w in data["waypoints"]:
+            if "latitude" in w:
+                request = FromLL.Request(ll_point=GeoPoint(latitude=w["latitude"], longitude=w["longitude"]))
+                future = from_ll_client.call_async(request)
+                rclpy.spin_until_future_complete(self, future)
+                point = Point2d.from_ros(future.result().map_point)
+            else:
+                point = Point2d(x=float(w["x"]), y=float(w["y"]))
+
+            waypoints.append(Waypoint(point=point, no_mans_land=bool(w.get("no_mans_land", False))))
+
+        return waypoints
 
     def transform_map_to_world(self, point: Point2d) -> Point2d | None:
         try:
             stamped = PointStamped(header=Header(frame_id=self.config.map_frame_id), point=point.to_ros())
             return Point2d.from_ros(self.tf_buffer.transform(stamped, self.config.world_frame_id).point)
-        except (tf2_ros.LookupException, tf2_ros.ConnectivityException, tf2_ros.ExtrapolationException) as e:
+        except TransformException as e:
             self.get_logger().error(f"TF transform failed: {e}")
             return None
 
     def publish_gps_waypoint(self) -> None:
-        map_point = self.waypoints[self.current_waypoint_index]
+        map_point = self.waypoints[self.current_waypoint_index].point
         self.get_logger().info(
-            f"Publishing gps waypoint ({map_point.x:.2f}, {map_point.y:.2f}) in {self.config.map_frame_id} frame"
+            f"Publishing waypoint ({map_point.x:.2f}, {map_point.y:.2f}) in {self.config.map_frame_id} frame"
         )
-        self.gps_waypoint_publisher.publish(
+        self.waypoint_publisher.publish(
             PointStamped(
                 header=Header(frame_id=self.config.map_frame_id, stamp=self.get_clock().now().to_msg()),
                 point=map_point.to_ros(),
@@ -106,42 +131,97 @@ class AutonavGoalSelection(Node):
         if self.robot_pose is None or self.current_waypoint_index >= len(self.waypoints):
             return
 
-        waypoint = self.transform_map_to_world(self.waypoints[self.current_waypoint_index])
+        waypoint = self.transform_map_to_world(self.waypoints[self.current_waypoint_index].point)
         if waypoint is None:
             return
 
-        if self.robot_pose.point.distance(waypoint) < self.config.waypoint_reached_threshold:
-            self.current_waypoint_index += 1
+        if self.robot_pose.point.distance(waypoint) >= self.config.waypoint_reached_threshold_m:
+            return
 
-            if self.current_waypoint_index >= len(self.waypoints):
-                self.get_logger().info("Final waypoint reached, stopping navigation")
-                return
+        if self.waypoints[self.current_waypoint_index].no_mans_land:
+            self.in_no_mans_land = not self.in_no_mans_land
+            self.get_logger().info(f"{'Entering' if self.in_no_mans_land else 'Exiting'} no man's land")
+            self.set_no_mans_land_client.call_async(SetBool.Request(data=self.in_no_mans_land))
 
-            self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
-            self.publish_gps_waypoint()
+        self.current_waypoint_index += 1
+
+        if self.current_waypoint_index >= len(self.waypoints):
+            self.get_logger().info("Final waypoint reached, stopping navigation")
+            return
+
+        self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
+        self.publish_gps_waypoint()
 
     def publish_goal(self) -> None:
         if self.robot_pose is None or self.grid is None or self.current_waypoint_index >= len(self.waypoints):
             return
 
-        waypoint = self.transform_map_to_world(self.waypoints[self.current_waypoint_index])
+        if self.in_recovery:
+            return
+
+        waypoint = self.transform_map_to_world(self.waypoints[self.current_waypoint_index].point)
         if waypoint is None:
             return
 
-        goal = select_goal(self.grid, self.robot_pose, waypoint, self.config.goal_selection_params)
-        if goal is None:
-            self.get_logger().warn("No drivable goal found in occupancy grid")
+        if self.robot_pose.point.distance(waypoint) < self.config.waypoint_approach_radius_m:
+            self.goal_selector.reset()
+            self.goal_publisher.publish(
+                PointStamped(
+                    header=Header(frame_id=self.config.world_frame_id, stamp=self.get_clock().now().to_msg()),
+                    point=waypoint.to_ros(),
+                )
+            )
             return
 
-        self.get_logger().info(
-            f"Publishing local goal ({goal.x:.2f}, {goal.y:.2f}) in {self.config.world_frame_id} frame"
-        )
+        if self.config.publish_debug:
+            goal, debug = self.goal_selector.step_debug(self.grid, self.robot_pose)
+            self.debug_publisher.publish(self.build_debug_markers(debug))
+        else:
+            goal = self.goal_selector.step(self.grid, self.robot_pose)
+
+        if goal is None:
+            self.get_logger().warn("No drivable goal found in occupancy grid")
+            self.goal_selector.reset()
+            self.set_recovery_client.call_async(SetBool.Request(data=True))
+            return
+
         self.goal_publisher.publish(
             PointStamped(
                 header=Header(frame_id=self.config.world_frame_id, stamp=self.get_clock().now().to_msg()),
                 point=goal.to_ros(),
             )
         )
+
+    def build_debug_markers(self, debug: GoalSelector.DebugInfo) -> MarkerArray:
+        assert self.robot_pose is not None
+
+        def marker(marker_id: int, marker_type: int, **kw) -> Marker:
+            # Stamp omitted intentionally to avoid TF extrapolation errors in rviz
+            header = Header(frame_id=self.config.world_frame_id)
+            return Marker(header=header, ns="goal_selection", id=marker_id, type=marker_type, action=Marker.ADD, **kw)
+
+        scores = [r.score for r in debug.rays]
+        score_min, score_max = min(scores), max(scores)
+        score_span = max(score_max - score_min, 1e-6)
+
+        rays_marker = marker(0, Marker.LINE_LIST, scale=Vector3(x=0.02, y=0.0, z=0.0))
+        thick_marker = marker(1, Marker.LINE_LIST, scale=Vector3(x=0.06, y=0.0, z=0.0))
+
+        for ray in debug.rays:
+            end = self.robot_pose.point + Point2d.unit(ray.angle) * ray.length
+            pts = [self.robot_pose.point.to_ros(), end.to_ros()]
+            if ray is debug.chosen:
+                thick_marker.points.extend(pts)
+                thick_marker.colors.extend([ColorRGBA(r=1.0, g=1.0, b=0.0, a=1.0)] * 2)
+            elif ray is debug.momentum_ray:
+                thick_marker.points.extend(pts)
+                thick_marker.colors.extend([ColorRGBA(r=0.2, g=0.4, b=1.0, a=0.8)] * 2)
+            else:
+                t = (ray.score - score_min) / score_span
+                rays_marker.points.extend(pts)
+                rays_marker.colors.extend([ColorRGBA(r=1.0 - t, g=t, b=0.0, a=0.8)] * 2)
+
+        return MarkerArray(markers=[rays_marker, thick_marker])
 
 
 def main() -> None:

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -200,24 +200,24 @@ class AutonavGoalSelection(Node):
             header = Header(frame_id=self.config.world_frame_id)
             return Marker(header=header, ns="goal_selection", id=marker_id, type=marker_type, action=Marker.ADD, **kw)
 
-        scores = [r.score for r in debug.rays]
+        scores = [result.score for result in debug.results]
         score_min, score_max = min(scores), max(scores)
         score_span = max(score_max - score_min, 1e-6)
 
         rays_marker = marker(0, Marker.LINE_LIST, scale=Vector3(x=0.02, y=0.0, z=0.0))
         thick_marker = marker(1, Marker.LINE_LIST, scale=Vector3(x=0.06, y=0.0, z=0.0))
 
-        for ray in debug.rays:
-            end = self.robot_pose.point + Point2d.unit(ray.angle) * ray.length
+        for result in debug.results:
+            end = self.robot_pose.point + Point2d.unit(result.ray.angle) * result.ray.length
             pts = [self.robot_pose.point.to_ros(), end.to_ros()]
-            if ray is debug.chosen:
+            if result is debug.chosen:
                 thick_marker.points.extend(pts)
                 thick_marker.colors.extend([ColorRGBA(r=1.0, g=1.0, b=0.0, a=1.0)] * 2)
-            elif ray is debug.momentum_ray:
+            elif result is debug.momentum:
                 thick_marker.points.extend(pts)
                 thick_marker.colors.extend([ColorRGBA(r=0.2, g=0.4, b=1.0, a=0.8)] * 2)
             else:
-                t = (ray.score - score_min) / score_span
+                t = (result.score - score_min) / score_span
                 rays_marker.points.extend(pts)
                 rays_marker.colors.extend([ColorRGBA(r=1.0 - t, g=t, b=0.0, a=0.8)] * 2)
 

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
@@ -134,7 +134,7 @@ class AutonavGoalSelectionConfig:
     goal_selection_params: GoalSelectionParams
     waypoints_file_path: pathlib.Path
     goal_publish_period_s: float = 0.25
-    waypoint_reached_threshold_m: float = 1.0
+    waypoint_reached_threshold_m: float = 1.5
     waypoint_approach_radius_m: float = 5.0
     map_frame_id: str = "map"
     world_frame_id: str = "odom"

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
@@ -1,10 +1,119 @@
+import math
 import pathlib
 from dataclasses import dataclass
+
+from utils.geometry import Rotation2d
+
+
+@dataclass(frozen=True)
+class MomentumParams:
+    """Controls all momentum behavior in the ray-cast goal selection.
+
+    Alignment factor for a ray at angle deviation `d` from momentum:
+        `alignment_floor + (1 - alignment_floor) * ((1 + cos(d)) / 2) ** alignment_gain`
+
+    Attributes:
+        alignment_gain: Sharpness of the penalty for off-axis rays. 0 disables the bias;
+            higher values penalize deviation more aggressively.
+        alignment_floor: Minimum alignment factor regardless of angle. Higher values mean even
+            anti-aligned rays retain most of their score.
+        obstacle_threshold_m: Free length of the momentum-aligned ray below which
+            momentum weight is reduced. Above this threshold momentum is fully applied; below it
+            the weight scales down so longer escape routes can win.
+        obstacle_gain: Exponent controlling the shape of the momentum scaling curve.
+            scale = (length / threshold) ** gain, clamped to [0, 1].
+            gain < 1: weight drops quickly even for moderately short rays.
+            gain = 1: linear drop.
+            gain > 1: weight stays near 1 until very close to 0, then drops sharply.
+        ema_alpha: EMA smoothing factor for the momentum angle. Each frame the stored
+            momentum drifts alpha * angular_diff toward the chosen ray. Lower values make momentum
+            change more slowly (stable in open space); higher values react faster to obstacles.
+            Typical range: 0.05-0.3.
+    """
+
+    alignment_gain: float = 2
+    alignment_floor: float = 0.1
+    obstacle_threshold_m: float = 4.0
+    obstacle_gain: float = 2.0
+    ema_alpha: float = 0.1
+
+    def __post_init__(self) -> None:
+        if self.alignment_gain < 0:
+            raise ValueError("MomentumParams: alignment_gain must be >= 0")
+        if not (0.0 <= self.alignment_floor < 1.0):
+            raise ValueError("MomentumParams: alignment_floor must be in [0, 1)")
+        if self.obstacle_threshold_m <= 0:
+            raise ValueError("MomentumParams: obstacle_threshold_m must be > 0")
+        if self.obstacle_gain <= 0:
+            raise ValueError("MomentumParams: obstacle_gain must be > 0")
+        if not (0.0 < self.ema_alpha <= 1.0):
+            raise ValueError("MomentumParams: ema_alpha must be in (0, 1]")
+
+    def factor(self, angle_diff: Rotation2d, momentum_ray_length: float) -> float:
+        clearance = min(1.0, momentum_ray_length / self.obstacle_threshold_m)
+        obstacle_scale = clearance**self.obstacle_gain
+        raw_alignment = ((1.0 + angle_diff.cos) / 2.0) ** self.alignment_gain
+        alignment = self.alignment_floor + (1.0 - self.alignment_floor) * raw_alignment
+        return 1.0 - obstacle_scale + obstacle_scale * alignment
+
+    def update_ema(self, current: Rotation2d, target: Rotation2d) -> Rotation2d:
+        return current + (target - current) * self.ema_alpha
 
 
 @dataclass(frozen=True)
 class GoalSelectionParams:
-    """Parameters controlling weighting for goal selection in the occupancy grid."""
+    """Parameters controlling the ray-cast goal selection heuristic.
+
+    Attributes:
+        arc_angle_rad: Full angular width (rad) of the forward arc; rays span symmetrically
+            around the robot's heading. math.pi = 180° forward semicircle.
+        ray_interval_rad: Angular spacing (rad) between adjacent rays. Controls density
+            independently of arc size; num_rays is derived as int(arc / interval) + 1.
+        step_size_m: Step size used when walking each ray; should be ~grid resolution.
+        momentum: All parameters controlling momentum strength, alignment bias, obstacle
+            scaling, and EMA smoothing.
+        min_goal_progress_m: Minimum length the chosen ray must have for a goal to be
+            published. If the highest-scoring ray's length is below this, `select_goal`
+            returns no goal (caller should treat as "stuck"). Set to 0 to always publish.
+        neighbor_smoothing_window: Number of neighbors on each side averaged into each ray's
+            score before picking. 0 disables smoothing.
+        safety_margin_m: Distance (m) the chosen endpoint is pulled back from where the ray
+            terminated.
+        max_unknown_forward_m: Mirror of path_planning: how far forward unknown cells are
+            considered drivable when walking a ray.
+        max_unknown_sideways_m: Mirror of path_planning: how far sideways unknown cells are
+            considered drivable when walking a ray.
+    """
+
+    momentum: MomentumParams
+    arc_angle_rad: float = math.pi
+    ray_interval_rad: float = math.radians(1.25)
+    step_size_m: float = 0.05
+    min_goal_progress_m: float = 0.9
+    safety_margin_m: float = 0.9
+    neighbor_smoothing_window: int = 2
+    max_unknown_forward_m: float = 5.0
+    max_unknown_sideways_m: float = 2.5
+
+    def __post_init__(self) -> None:
+        if not (0 < self.arc_angle_rad <= 2 * math.pi):
+            raise ValueError("GoalSelectionParams: arc_angle_rad must be in (0, 2*pi]")
+        if self.ray_interval_rad <= 0:
+            raise ValueError("GoalSelectionParams: ray_interval_rad must be > 0")
+        if self.step_size_m <= 0:
+            raise ValueError("GoalSelectionParams: step_size_m must be > 0")
+        if self.min_goal_progress_m < 0:
+            raise ValueError("GoalSelectionParams: min_goal_progress_m must be >= 0")
+        if self.safety_margin_m < 0:
+            raise ValueError("GoalSelectionParams: safety_margin_m must be >= 0")
+        if self.min_goal_progress_m < self.safety_margin_m:
+            raise ValueError("GoalSelectionParams: min_goal_progress_m must be >= safety_margin_m")
+        if self.neighbor_smoothing_window < 0:
+            raise ValueError("GoalSelectionParams: neighbor_smoothing_window must be >= 0")
+        if self.max_unknown_forward_m < 0:
+            raise ValueError("GoalSelectionParams: max_unknown_forward_m must be >= 0")
+        if self.max_unknown_sideways_m < 0:
+            raise ValueError("GoalSelectionParams: max_unknown_sideways_m must be >= 0")
 
 
 @dataclass(frozen=True)
@@ -12,23 +121,32 @@ class AutonavGoalSelectionConfig:
     """Configuration for autonomous navigation goal selection.
 
     Attributes:
-        goal_selection_params: Parameters for the goal selection algorithm.
-        waypoints_file_path: Path to a JSON file containing the list of GPS waypoints to navigate.
+        goal_selection_params: Parameters for the ray-cast goal selection algorithm.
+        waypoints_file_path: Path to a JSON file containing the list of map-frame waypoints.
+            Expected format: {"waypoints": [{"x": <float>, "y": <float>}, ...]}.
         goal_publish_period_s: How often (seconds) to publish a new local goal.
-        waypoint_reached_threshold: Distance (m) within which a waypoint is considered reached.
+        waypoint_reached_threshold_m: Distance (m) within which a waypoint is considered reached.
+        waypoint_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal
+            selection is bypassed and the waypoint itself is published directly as the goal.
         map_frame_id: TF frame ID for the map coordinate frame.
         world_frame_id: TF frame ID for the world coordinate frame.
+        publish_debug: When true, publish a MarkerArray on `goal_selection_debug` showing all
+            rays, the chosen ray, the chosen endpoint, and the waypoint direction.
     """
 
     goal_selection_params: GoalSelectionParams
     waypoints_file_path: pathlib.Path
-    goal_publish_period_s: float = 5.0
-    waypoint_reached_threshold: float = 1.0
+    goal_publish_period_s: float = 0.25
+    waypoint_reached_threshold_m: float = 1.0
+    waypoint_approach_radius_m: float = 5.0
     map_frame_id: str = "map"
     world_frame_id: str = "odom"
+    publish_debug: bool = True
 
     def __post_init__(self) -> None:
         if self.goal_publish_period_s <= 0:
             raise ValueError("AutonavGoalSelectionConfig: goal_publish_period_s must be > 0")
-        if self.waypoint_reached_threshold <= 0:
-            raise ValueError("AutonavGoalSelectionConfig: waypoint_reached_threshold must be > 0")
+        if self.waypoint_reached_threshold_m <= 0:
+            raise ValueError("AutonavGoalSelectionConfig: waypoint_reached_threshold_m must be > 0")
+        if self.waypoint_approach_radius_m < 0:
+            raise ValueError("AutonavGoalSelectionConfig: waypoint_approach_radius_m must be >= 0")

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
@@ -9,25 +9,21 @@ from utils.geometry import Rotation2d
 class MomentumParams:
     """Controls all momentum behavior in the ray-cast goal selection.
 
-    Alignment factor for a ray at angle deviation `d` from momentum:
-        `alignment_floor + (1 - alignment_floor) * ((1 + cos(d)) / 2) ** alignment_gain`
-
     Attributes:
-        alignment_gain: Sharpness of the penalty for off-axis rays. 0 disables the bias;
-            higher values penalize deviation more aggressively.
-        alignment_floor: Minimum alignment factor regardless of angle. Higher values mean even
-            anti-aligned rays retain most of their score.
-        obstacle_threshold_m: Free length of the momentum-aligned ray below which
-            momentum weight is reduced. Above this threshold momentum is fully applied; below it
-            the weight scales down so longer escape routes can win.
+        alignment_gain: Sharpness of the penalty for rays misaligned with the momentum ray. 0 disables the bias; higher
+            values penalize deviation more aggressively.
+        alignment_floor: Minimum alignment factor regardless of angle. Higher values mean even anti-aligned rays retain
+            most of their score.
+        obstacle_threshold_m: Free length of the momentum-aligned ray below which momentum weight is reduced. Above this
+            threshold momentum is fully applied; below it the weight scales down so longer escape routes can win.
         obstacle_gain: Exponent controlling the shape of the momentum scaling curve.
             scale = (length / threshold) ** gain, clamped to [0, 1].
             gain < 1: weight drops quickly even for moderately short rays.
             gain = 1: linear drop.
             gain > 1: weight stays near 1 until very close to 0, then drops sharply.
-        ema_alpha: EMA smoothing factor for the momentum angle. Each frame the stored
-            momentum drifts alpha * angular_diff toward the chosen ray. Lower values make momentum
-            change more slowly (stable in open space); higher values react faster to obstacles.
+        ema_alpha: EMA smoothing factor for the momentum angle. Each frame the stored momentum drifts alpha *
+            angular_diff toward the chosen ray. Lower values make momentum change more slowly (stable in open space);
+            higher values react faster to obstacles.
             Typical range: 0.05-0.3.
     """
 
@@ -50,6 +46,10 @@ class MomentumParams:
             raise ValueError("MomentumParams: ema_alpha must be in (0, 1]")
 
     def factor(self, angle_diff: Rotation2d, momentum_ray_length: float) -> float:
+        """
+        Alignment factor for a ray at angle deviation `d` from momentum:
+            `alignment_floor + (1 - alignment_floor) * ((1 + cos(d)) / 2) ** alignment_gain`
+        """
         clearance = min(1.0, momentum_ray_length / self.obstacle_threshold_m)
         obstacle_scale = clearance**self.obstacle_gain
         raw_alignment = ((1.0 + angle_diff.cos) / 2.0) ** self.alignment_gain
@@ -65,24 +65,22 @@ class GoalSelectionParams:
     """Parameters controlling the ray-cast goal selection heuristic.
 
     Attributes:
-        momentum: All parameters controlling momentum strength, alignment bias, obstacle
-            scaling, and EMA smoothing.
-        arc_angle_rad: Full angular width (rad) of the forward arc; rays span symmetrically
-            around the robot's heading. math.pi = 180° forward semicircle.
-        ray_interval_rad: Angular spacing (rad) between adjacent rays. Controls density
-            independently of arc size; num_rays is derived as int(arc / interval) + 1.
+        momentum: All parameters controlling momentum strength, alignment bias, obstacle scaling, and EMA smoothing.
+        arc_angle_rad: Full angular width (rad) of the forward arc; rays span symmetrically around the robot's heading.
+            math.pi = 180° forward semicircle.
+        ray_interval_rad: Angular spacing (rad) between adjacent rays. Controls density independently of arc size;
+            num_rays is derived as int(arc / interval) + 1.
         step_size_m: Step size used when walking each ray; should be ~grid resolution.
-        min_goal_progress_m: Minimum length the chosen ray must have for a goal to be
-            published. If the highest-scoring ray's length is below this, `select_goal`
-            returns no goal (caller should treat as "stuck"). Set to 0 to always publish.
-        safety_margin_m: Distance (m) the chosen endpoint is pulled back from where the ray
-            terminated.
-        neighbor_smoothing_window: Number of neighbors on each side averaged into each ray's
-            score before picking. 0 disables smoothing.
-        max_unknown_forward_m: Mirror of path_planning: how far forward unknown cells are
-            considered drivable when walking a ray.
-        max_unknown_sideways_m: Mirror of path_planning: how far sideways unknown cells are
-            considered drivable when walking a ray.
+        min_goal_progress_m: Minimum length the chosen ray must have for a goal to be published. If the highest-scoring
+            ray's length is below this, `select_goal` returns no goal (caller should treat as "stuck"). Set to 0 to
+            always publish.
+        safety_margin_m: Distance (m) the chosen endpoint is pulled back from where the ray terminated.
+        neighbor_smoothing_window: Number of neighbors on each side averaged into each ray's score before picking. 0
+            disables smoothing.
+        max_unknown_forward_m: Mirror of path_planning: how far forward unknown cells are considered drivable when
+            walking a ray.
+        max_unknown_sideways_m: Mirror of path_planning: how far sideways unknown cells are considered drivable when
+            walking a ray.
     """
 
     momentum: MomentumParams
@@ -123,15 +121,14 @@ class AutonavGoalSelectionConfig:
     Attributes:
         goal_selection_params: Parameters for the ray-cast goal selection algorithm.
         waypoints_file_path: Path to a JSON file containing the list of map-frame waypoints.
-            Expected format: {"waypoints": [{"x": <float>, "y": <float>}, ...]}.
         goal_publish_period_s: How often (seconds) to publish a new local goal.
         waypoint_reached_threshold_m: Distance (m) within which a waypoint is considered reached.
-        waypoint_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal
-            selection is bypassed and the waypoint itself is published directly as the goal.
+        waypoint_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal selection is bypassed and
+            the waypoint itself is published directly as the goal.
         map_frame_id: TF frame ID for the map coordinate frame.
         world_frame_id: TF frame ID for the world coordinate frame.
-        publish_debug: When true, publish a MarkerArray on `goal_selection_debug` showing all
-            rays, the chosen ray, the chosen endpoint, and the waypoint direction.
+        publish_debug: When true, publish a MarkerArray on `goal_selection_debug` showing all rays, the chosen ray, the
+            chosen endpoint, and the waypoint direction.
     """
 
     goal_selection_params: GoalSelectionParams

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
@@ -65,20 +65,20 @@ class GoalSelectionParams:
     """Parameters controlling the ray-cast goal selection heuristic.
 
     Attributes:
+        momentum: All parameters controlling momentum strength, alignment bias, obstacle
+            scaling, and EMA smoothing.
         arc_angle_rad: Full angular width (rad) of the forward arc; rays span symmetrically
             around the robot's heading. math.pi = 180° forward semicircle.
         ray_interval_rad: Angular spacing (rad) between adjacent rays. Controls density
             independently of arc size; num_rays is derived as int(arc / interval) + 1.
         step_size_m: Step size used when walking each ray; should be ~grid resolution.
-        momentum: All parameters controlling momentum strength, alignment bias, obstacle
-            scaling, and EMA smoothing.
         min_goal_progress_m: Minimum length the chosen ray must have for a goal to be
             published. If the highest-scoring ray's length is below this, `select_goal`
             returns no goal (caller should treat as "stuck"). Set to 0 to always publish.
-        neighbor_smoothing_window: Number of neighbors on each side averaged into each ray's
-            score before picking. 0 disables smoothing.
         safety_margin_m: Distance (m) the chosen endpoint is pulled back from where the ray
             terminated.
+        neighbor_smoothing_window: Number of neighbors on each side averaged into each ray's
+            score before picking. 0 disables smoothing.
         max_unknown_forward_m: Mirror of path_planning: how far forward unknown cells are
             considered drivable when walking a ray.
         max_unknown_sideways_m: Mirror of path_planning: how far sideways unknown cells are
@@ -98,8 +98,8 @@ class GoalSelectionParams:
     def __post_init__(self) -> None:
         if not (0 < self.arc_angle_rad <= 2 * math.pi):
             raise ValueError("GoalSelectionParams: arc_angle_rad must be in (0, 2*pi]")
-        if self.ray_interval_rad <= 0:
-            raise ValueError("GoalSelectionParams: ray_interval_rad must be > 0")
+        if not (0 < self.ray_interval_rad <= self.arc_angle_rad):
+            raise ValueError("GoalSelectionParams: ray_interval_rad must be in (0, arc_angle_rad]")
         if self.step_size_m <= 0:
             raise ValueError("GoalSelectionParams: step_size_m must be > 0")
         if self.min_goal_progress_m < 0:

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_impl.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_impl.py
@@ -1,34 +1,103 @@
-import math
+from __future__ import annotations
 
-from utils.geometry import Point2d, Pose2d
+from dataclasses import dataclass
+
+from utils.geometry import Point2d, Pose2d, Rotation2d
 from utils.world_occupancy_grid import WorldOccupancyGrid
 
 from .autonav_goal_selection_config import GoalSelectionParams
 
 
-def select_goal(
-    grid: WorldOccupancyGrid, robot_pose: Pose2d, waypoint: Point2d, params: GoalSelectionParams
-) -> Point2d | None:
-    """Select the best drivable goal in the occupancy grid.
+class GoalSelector:
+    @dataclass(frozen=True)
+    class RayCast:
+        angle: Rotation2d  # world frame
+        length: float
 
-    Scores every in-bounds drivable cell using a heuristic and returns
-    the highest-scoring point. Non-drivable cells are excluded.
+    @dataclass(frozen=True)
+    class RayCastResult:
+        angle: Rotation2d  # world frame
+        length: float
+        score: float
 
-    Args:
-        grid: World-coordinate occupancy grid.
-        robot_pose: Robot pose in world coordinates.
-        waypoint: Target waypoint in world coordinates.
-        params: Goal selection algorithm parameters.
-    Returns:
-        The best drivable goal point, or None if no drivable cells exist.
-    """
+    @dataclass(frozen=True)
+    class DebugInfo:
+        rays: list[GoalSelector.RayCastResult]
+        chosen: GoalSelector.RayCastResult | None
+        momentum_ray: GoalSelector.RayCastResult
 
-    def heuristic(point: Point2d) -> float:
-        if not grid.state(point).is_drivable:
-            return math.inf
+    def __init__(self, params: GoalSelectionParams) -> None:
+        self.params = params
+        self.momentum_angle: Rotation2d | None = None
 
-        # This is a bad heuristic but it works fine for open fields
-        return point.distance(waypoint)
+    def step(self, grid: WorldOccupancyGrid, robot_pose: Pose2d) -> Point2d | None:
+        goal, _ = self.step_debug(grid, robot_pose)
+        return goal
 
-    best_point = min(grid.in_bound_points(Point2d), key=heuristic)
-    return best_point if heuristic(best_point) < math.inf else None
+    def step_debug(self, grid: WorldOccupancyGrid, robot_pose: Pose2d) -> tuple[Point2d | None, GoalSelector.DebugInfo]:
+        casts = self.cast_rays(grid, robot_pose)
+
+        momentum_angle = self.momentum_angle if self.momentum_angle is not None else robot_pose.rotation
+        momentum_index = min(range(len(casts)), key=lambda i: abs((casts[i].angle - momentum_angle).angle))
+
+        scores = self.smooth_scores(self.score_rays(casts, casts[momentum_index]))
+        rays = [GoalSelector.RayCastResult(w.angle, w.length, s) for w, s in zip(casts, scores, strict=True)]
+
+        chosen = max(rays, key=lambda r: r.score)
+        if chosen.length < self.params.min_goal_progress_m:
+            return None, GoalSelector.DebugInfo(rays=rays, chosen=None, momentum_ray=rays[momentum_index])
+
+        goal = robot_pose.point + Point2d.unit(chosen.angle) * (chosen.length - self.params.safety_margin_m)
+        self.momentum_angle = (
+            chosen.angle
+            if self.momentum_angle is None
+            else self.params.momentum.update_ema(self.momentum_angle, chosen.angle)
+        )
+        return goal, GoalSelector.DebugInfo(rays=rays, chosen=chosen, momentum_ray=rays[momentum_index])
+
+    def reset(self) -> None:
+        self.momentum_angle = None
+
+    def cast_rays(self, grid: WorldOccupancyGrid, robot_pose: Pose2d) -> list[GoalSelector.RayCast]:
+        num_rays = int(self.params.arc_angle_rad / self.params.ray_interval_rad) + 1
+        start_angle = robot_pose.rotation - Rotation2d(self.params.arc_angle_rad / 2)
+
+        casts: list[GoalSelector.RayCast] = []
+        for i in range(num_rays):
+            angle = start_angle + Rotation2d(i * self.params.ray_interval_rad)
+            step_vector = Point2d.unit(angle) * self.params.step_size_m
+            point = robot_pose.point
+
+            while True:
+                point = point + step_vector
+                state = grid.state(point)
+
+                if state.is_unknown:
+                    local = robot_pose.world_to_local(point)
+                    in_box = (
+                        0 <= local.x <= self.params.max_unknown_forward_m
+                        and abs(local.y) <= self.params.max_unknown_sideways_m
+                    )
+                    if not in_box:
+                        break
+                elif not state.is_drivable:
+                    break
+
+            casts.append(GoalSelector.RayCast(angle, robot_pose.point.distance(point) - self.params.step_size_m))
+
+        return casts
+
+    def score_rays(self, casts: list[GoalSelector.RayCast], momentum: GoalSelector.RayCast) -> list[float]:
+        return [w.length * self.params.momentum.factor(w.angle - momentum.angle, momentum.length) for w in casts]
+
+    def smooth_scores(self, scores: list[float]) -> list[float]:
+        window = self.params.neighbor_smoothing_window
+        if window <= 0:
+            return list(scores)
+
+        smoothed: list[float] = []
+        for i in range(len(scores)):
+            lo = max(0, i - window)
+            hi = min(len(scores), i + window + 1)
+            smoothed.append(sum(scores[lo:hi]) / (hi - lo))
+        return smoothed

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_impl.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_impl.py
@@ -74,11 +74,11 @@ class GoalSelector:
 
                 if state.is_unknown:
                     local = robot_pose.world_to_local(point)
-                    in_box = (
+                    within_unknown_limits = (
                         0 <= local.x <= self.params.max_unknown_forward_m
                         and abs(local.y) <= self.params.max_unknown_sideways_m
                     )
-                    if not in_box:
+                    if not within_unknown_limits:
                         break
                 elif not state.is_drivable:
                     break

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_impl.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_impl.py
@@ -10,21 +10,20 @@ from .autonav_goal_selection_config import GoalSelectionParams
 
 class GoalSelector:
     @dataclass(frozen=True)
-    class RayCast:
+    class Ray:
         angle: Rotation2d  # world frame
         length: float
 
     @dataclass(frozen=True)
-    class RayCastResult:
-        angle: Rotation2d  # world frame
-        length: float
+    class RayResult:
+        ray: GoalSelector.Ray
         score: float
 
     @dataclass(frozen=True)
     class DebugInfo:
-        rays: list[GoalSelector.RayCastResult]
-        chosen: GoalSelector.RayCastResult | None
-        momentum_ray: GoalSelector.RayCastResult
+        results: list[GoalSelector.RayResult]
+        chosen: GoalSelector.RayResult | None
+        momentum: GoalSelector.RayResult
 
     def __init__(self, params: GoalSelectionParams) -> None:
         self.params = params
@@ -35,34 +34,34 @@ class GoalSelector:
         return goal
 
     def step_debug(self, grid: WorldOccupancyGrid, robot_pose: Pose2d) -> tuple[Point2d | None, GoalSelector.DebugInfo]:
-        casts = self.cast_rays(grid, robot_pose)
+        rays = self.cast_rays(grid, robot_pose)
 
         momentum_angle = self.momentum_angle if self.momentum_angle is not None else robot_pose.rotation
-        momentum_index = min(range(len(casts)), key=lambda i: abs((casts[i].angle - momentum_angle).angle))
+        momentum_index = min(range(len(rays)), key=lambda i: abs((rays[i].angle - momentum_angle).angle))
 
-        scores = self.smooth_scores(self.score_rays(casts, casts[momentum_index]))
-        rays = [GoalSelector.RayCastResult(w.angle, w.length, s) for w, s in zip(casts, scores, strict=True)]
+        scores = self.smooth_scores(self.score_rays(rays, rays[momentum_index]))
+        results = [GoalSelector.RayResult(w, s) for w, s in zip(rays, scores, strict=True)]
 
-        chosen = max(rays, key=lambda r: r.score)
-        if chosen.length < self.params.min_goal_progress_m:
-            return None, GoalSelector.DebugInfo(rays=rays, chosen=None, momentum_ray=rays[momentum_index])
+        chosen = max(results, key=lambda r: r.score)
+        if chosen.ray.length < self.params.min_goal_progress_m:
+            return None, GoalSelector.DebugInfo(results=results, chosen=None, momentum=results[momentum_index])
 
-        goal = robot_pose.point + Point2d.unit(chosen.angle) * (chosen.length - self.params.safety_margin_m)
+        goal = robot_pose.point + Point2d.unit(chosen.ray.angle) * (chosen.ray.length - self.params.safety_margin_m)
         self.momentum_angle = (
-            chosen.angle
+            chosen.ray.angle
             if self.momentum_angle is None
-            else self.params.momentum.update_ema(self.momentum_angle, chosen.angle)
+            else self.params.momentum.update_ema(self.momentum_angle, chosen.ray.angle)
         )
-        return goal, GoalSelector.DebugInfo(rays=rays, chosen=chosen, momentum_ray=rays[momentum_index])
+        return goal, GoalSelector.DebugInfo(results=results, chosen=chosen, momentum=results[momentum_index])
 
     def reset(self) -> None:
         self.momentum_angle = None
 
-    def cast_rays(self, grid: WorldOccupancyGrid, robot_pose: Pose2d) -> list[GoalSelector.RayCast]:
+    def cast_rays(self, grid: WorldOccupancyGrid, robot_pose: Pose2d) -> list[GoalSelector.Ray]:
         num_rays = int(self.params.arc_angle_rad / self.params.ray_interval_rad) + 1
         start_angle = robot_pose.rotation - Rotation2d(self.params.arc_angle_rad / 2)
 
-        casts: list[GoalSelector.RayCast] = []
+        rays: list[GoalSelector.Ray] = []
         for i in range(num_rays):
             angle = start_angle + Rotation2d(i * self.params.ray_interval_rad)
             step_vector = Point2d.unit(angle) * self.params.step_size_m
@@ -83,12 +82,12 @@ class GoalSelector:
                 elif not state.is_drivable:
                     break
 
-            casts.append(GoalSelector.RayCast(angle, robot_pose.point.distance(point) - self.params.step_size_m))
+            rays.append(GoalSelector.Ray(angle, robot_pose.point.distance(point) - self.params.step_size_m))
 
-        return casts
+        return rays
 
-    def score_rays(self, casts: list[GoalSelector.RayCast], momentum: GoalSelector.RayCast) -> list[float]:
-        return [w.length * self.params.momentum.factor(w.angle - momentum.angle, momentum.length) for w in casts]
+    def score_rays(self, rays: list[GoalSelector.Ray], momentum: GoalSelector.Ray) -> list[float]:
+        return [w.length * self.params.momentum.factor(w.angle - momentum.angle, momentum.length) for w in rays]
 
     def smooth_scores(self, scores: list[float]) -> list[float]:
         window = self.params.neighbor_smoothing_window

--- a/src/navigation/autonav_goal_selection/package.xml
+++ b/src/navigation/autonav_goal_selection/package.xml
@@ -8,14 +8,16 @@
   <license>Apache-2.0</license>
 
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>geographic_msgs</exec_depend>
+  <exec_depend>geometry_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
+  <exec_depend>std_srvs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>utils</exec_depend>
+  <exec_depend>visualization_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   
   <test_depend>ament_copyright</test_depend>


### PR DESCRIPTION
Closes #3

## What has changed
Change goal selection strategy to cast rays from the uninflated occupancy grid and pick the best ray as a heuristic. This ensures that we don't ever handle goals outside of the lane lines 

## Testing plan
Tested in simulation with the new simulated occupancy grid