### PR TITLE
use https url for submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src/hardware/vectornav"]
 	path = src/hardware/vectornav
-	url = git@github.com:umigv/vectornav.git
+	url = https://github.com/umigv/vectornav.git


### PR DESCRIPTION
it's more accessible for users who don't have ssh keys set up (including the ARV laptop)
i think there's no upside for ssh since it's a public repo