### PR TITLE
fix: add stopped state so robot does not continue driving when it reaches final waypoint

### DIFF
--- a/src/core/state_machine/README.md
+++ b/src/core/state_machine/README.md
@@ -4,18 +4,19 @@ machine exposes services for state transitions and publishes the robot state to 
 to and react accordingly.
 
 ## States
-There are three mutually exclusive states:
+There are four mutually exclusive states:
 - **`normal`** – default operating mode  
 - **`no_mans_land`** – no mans land-specific behavior enabled  
 - **`recovery`** – recovery / fault handling mode  
+- **`finished`** – all waypoints reached; robot is forced to stop and stays stopped  
 
-1. State priority is fixed and deterministic: recovery > no_mans_land > normal
+1. State priority is fixed and deterministic: finished > recovery > no_mans_land > normal
 2. States are published only on state changes
 3. On startup, the node immediately publishes the initial state (`normal`)
 4. Late-joining subscribers immediately receive the most recent state
 
 ## Published Topics
-- `state` (`std_msgs/String`) - The current robot state as one of `"normal"`, `"no_mans_land"`, or `"recovery"`
+- `state` (`std_msgs/String`) - The current robot state as one of `"normal"`, `"no_mans_land"`, `"recovery"`, or `"finished"`
 
 The `state` topic uses a non-default QoS profile:
 | Setting | Value | Effect |
@@ -31,6 +32,7 @@ In code, use `utils.qos.LATCHED`. In RViz, set the topic's **Durability Policy**
 ## Services
 - `state/set_no_mans_land` (`std_srvs/SetBool`) - Enable or disable no_mans_land mode
 - `state/set_recovery` (`std_srvs/SetBool`) - Enable or disable recovery mode
+- `state/set_finished` (`std_srvs/SetBool`) - Signal that all waypoints have been reached; takes priority over all other states
 
 ## Example Usage
 ```bash
@@ -39,4 +41,5 @@ ros2 service call /state/set_no_mans_land std_srvs/srv/SetBool "{data: true}" # 
 ros2 service call /state/set_recovery std_srvs/srv/SetBool "{data: true}" # Enter recovery mode (overrides no_mans_land)
 ros2 service call /state/set_recovery std_srvs/srv/SetBool "{data: false}" # Exit recovery mode
 ros2 service call /state/set_no_mans_land std_srvs/srv/SetBool "{data: false}" # Disable no_mans_land mode
+ros2 service call /state/set_finished std_srvs/srv/SetBool "{data: true}" # Signal navigation complete (overrides all states)
 ```

--- a/src/core/state_machine/state_machine/state_machine.py
+++ b/src/core/state_machine/state_machine/state_machine.py
@@ -11,6 +11,7 @@ class State(str, Enum):
     NORMAL = "normal"
     NO_MANS_LAND = "no_mans_land"
     RECOVERY = "recovery"
+    FINISHED = "finished"
 
 
 class StateMachine(Node):
@@ -29,9 +30,15 @@ class StateMachine(Node):
         self.set_recovery_service = self.create_service(SetBool, "state/set_recovery", self.set_recovery_callback)
         self.recovery_enabled: bool = False
 
+        self.set_finished_service = self.create_service(SetBool, "state/set_finished", self.set_finished_callback)
+        self.finished_enabled: bool = False
+
         self.publish_state_if_changed(reason="init")
 
     def compute_state(self) -> State:
+        if self.finished_enabled:
+            return State.FINISHED
+
         if self.recovery_enabled:
             return State.RECOVERY
 
@@ -61,6 +68,18 @@ class StateMachine(Node):
         res.success = True
         self.get_logger().info(res.message + f" (no_mans_land_enabled={self.no_mans_land_enabled})")
         self.publish_state_if_changed(reason="state/set_recovery")
+        return res
+
+    def set_finished_callback(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
+        if req.data == self.finished_enabled:
+            res.message = f"Finished already {'enabled' if req.data else 'disabled'}."
+        else:
+            res.message = f"Finished {'enabled' if req.data else 'disabled'}."
+
+        self.finished_enabled = req.data
+        res.success = True
+        self.get_logger().info(res.message)
+        self.publish_state_if_changed(reason="state/set_finished")
         return res
 
     def set_no_mans_land_callback(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -10,6 +10,7 @@ from geometry_msgs.msg import PointStamped, Vector3
 from nav_msgs.msg import OccupancyGrid, Odometry
 from rclpy.node import Node
 from std_msgs.msg import ColorRGBA, Header
+from std_srvs.srv import SetBool
 from tf2_ros import TransformException
 from utils.geometry import Point2d, Pose2d
 from utils.world_occupancy_grid import WorldOccupancyGrid
@@ -42,6 +43,8 @@ class AutonavGoalSelection(Node):
         self.debug_publisher = (
             self.create_publisher(MarkerArray, "goal_selection_debug", 10) if self.config.publish_debug else None
         )
+
+        self.set_finished_client = self.create_client(SetBool, "state/set_finished")
 
         self.create_timer(self.config.goal_publish_period_s, self.publish_goal)
         self.publish_gps_waypoint()
@@ -104,10 +107,19 @@ class AutonavGoalSelection(Node):
 
             if self.current_waypoint_index >= len(self.waypoints):
                 self.get_logger().info("Final waypoint reached, stopping navigation")
+                self._call_set_finished()
                 return
 
             self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
             self.publish_gps_waypoint()
+
+    def _call_set_finished(self) -> None:
+        req = SetBool.Request()
+        req.data = True
+        future = self.set_finished_client.call_async(req)
+        future.add_done_callback(
+            lambda f: self.get_logger().error(f"set_finished call failed: {f.exception()}") if f.exception() else None
+        )
 
     def publish_goal(self) -> None:
         if self.robot_pose is None or self.grid is None or self.current_waypoint_index >= len(self.waypoints):

--- a/src/navigation/path_tracking/path_tracking/path_tracking.py
+++ b/src/navigation/path_tracking/path_tracking/path_tracking.py
@@ -2,9 +2,11 @@ import math
 
 import rclpy
 import utils.config
+import utils.qos
 from geometry_msgs.msg import Twist
 from nav_msgs.msg import Odometry, Path
 from rclpy.node import Node
+from std_msgs.msg import String
 from utils.geometry import Path2d, Pose2d
 
 from .path_tracking_config import PathTrackingConfig
@@ -27,9 +29,11 @@ class PathTracking(Node):
 
         self.pose: Pose2d | None = None
         self.current_speed: float = 0.0
+        self.finished: bool = False
 
         self.create_subscription(Odometry, "odom", self.odom_callback, 10)
         self.create_subscription(Path, "path", self.path_callback, 10)
+        self.create_subscription(String, "state", self.state_callback, utils.qos.LATCHED)
 
         self.cmd_vel_publisher = self.create_publisher(Twist, "nav_cmd_vel", 10)
 
@@ -49,6 +53,11 @@ class PathTracking(Node):
         self.pose = Pose2d.from_ros(msg.pose.pose)
         self.current_speed = math.hypot(msg.twist.twist.linear.x, msg.twist.twist.linear.y)
 
+    def state_callback(self, msg: String) -> None:
+        if msg.data == "finished" and not self.finished:
+            self.get_logger().info("State is finished, stopping robot")
+            self.finished = True
+
     def path_callback(self, path_msg: Path) -> None:
         if path_msg.header.frame_id != self.config.odom_frame_id:
             self.get_logger().warn(
@@ -67,6 +76,10 @@ class PathTracking(Node):
 
     def control_loop(self) -> None:
         if self.pose is None:
+            return
+
+        if self.finished:
+            self.cmd_vel_publisher.publish(Twist())
             return
 
         cmd = self.controller.compute_command(self.pose, self.current_speed)


### PR DESCRIPTION
I think the stopped state is a good idea and good solution to the problem, but it might be better to move the `path_tracking` `finished` check somewhere else so it doesn't rely on receiving another path after `finished` has triggered