### PR TITLE
Add periodic safety check for odrive_driver

### DIFF
--- a/scripts/calibrate_odrive.py
+++ b/scripts/calibrate_odrive.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python3
-import time
-
 import odrive
+import odrive.utils
 from odrive.enums import AxisState
 
 
@@ -9,19 +8,8 @@ def calibrate_odrive(serial_number: str) -> None:
     print(f"Finding ODrive with serial number {serial_number}...")
     odrv = odrive.find_any(serial_number=serial_number)
 
-    print("Clearing pre-existing errors...")
-    odrv.clear_errors()
-
-    print("Starting calibration...")
     print("There should be a beep and the indicator lights should flash green. Do not touch the robot!")
-    odrv.axis0.requested_state = AxisState.FULL_CALIBRATION_SEQUENCE
-
-    # Wait for the ODrive to leave idle, confirming calibration has started
-    while odrv.axis0.current_state == AxisState.IDLE:
-        time.sleep(0.1)
-
-    while odrv.axis0.current_state != AxisState.IDLE:
-        time.sleep(0.1)
+    odrive.utils.run_state(odrv.axis0, AxisState.FULL_CALIBRATION_SEQUENCE)  # type: ignore[reportUnusedCoroutine]
 
     print(f"ODrive {serial_number} calibrated!")
 

--- a/src/hardware/odrive_driver/README.md
+++ b/src/hardware/odrive_driver/README.md
@@ -1,6 +1,7 @@
 # odrive_driver
 Controls two ODrives (left and right) over USB. Converts `cmd_vel` twist commands to per-motor velocity setpoints and
-publishes encoder-derived velocity with propagated covariance.
+publishes encoder-derived velocity with propagated covariance. Motors are zeroed if no `cmd_vel` is received within
+`cmd_vel_timeout_s` or if the e-stop is active.
 
 ## Read Files
 - `/tmp/estop_value.txt` - e-stop state written by `estop_driver`; commands zero velocity to both motors while estopped
@@ -15,7 +16,8 @@ covariance
 ## Config Parameters
 | Parameter | Type | Default | Description |
 |---|---|---|---|
-| `sample_time_s` | `float` | `0.01` | Period (s) of the encoder publish timer |
+| `publish_period_s` | `float` | `0.01` | Period (s) of the encoder publish timer |
+| `cmd_vel_timeout_s` | `float` | `0.5` | Max age of a `cmd_vel` command before motors are zeroed (s) |
 | `timestamp_delay_s` | `float` | `0.0` | Subtracted from the publish timestamp to compensate read and processing latency (s) |
 | `frame_id` | `str` | `"base_link"` | TF frame ID attached to the published twist header |
 | `estop_file_path` | `Path` | `/tmp/estop_value.txt` | Path to the e-stop flag file |

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
@@ -1,8 +1,9 @@
 import odrive
+import odrive.utils
 import rclpy
 import utils.config
 from geometry_msgs.msg import Twist, TwistWithCovariance, TwistWithCovarianceStamped, Vector3
-from odrive.enums import AxisState, ControlMode
+from odrive.enums import AxisState, ControlMode, ODriveError
 from rclpy.duration import Duration
 from rclpy.node import Node
 from std_msgs.msg import Header
@@ -16,23 +17,29 @@ class OdriveDriver(Node):
 
         self.config = utils.config.load(self, OdriveDriverConfig)
 
-        self.get_logger().info(f"Finding left ODrive (serial number {self.config.left_odrive.serial})...")
-        self.odrive_left = odrive.find_any(serial_number=self.config.left_odrive.serial)
-        self.initialize_odrive(self.odrive_left)
-        self.get_logger().info("Found left ODrive")
-
-        self.get_logger().info(f"Finding right ODrive (serial number {self.config.right_odrive.serial})...")
-        self.odrive_right = odrive.find_any(serial_number=self.config.right_odrive.serial)
-        self.initialize_odrive(self.odrive_right)
-        self.get_logger().info("Found right ODrive")
-
         self.create_subscription(Twist, "cmd_vel", self.cmd_vel_callback, 10)
 
         self.publisher = self.create_publisher(TwistWithCovarianceStamped, "enc_vel", 10)
 
         self.create_timer(self.config.sample_time_s, self.publish_enc_vel)
 
-    def cmd_vel_callback(self, msg):
+    def init(self) -> bool:
+        try:
+            self.get_logger().info(f"Finding left ODrive (serial number {self.config.left_odrive.serial})...")
+            self.odrive_left = odrive.find_any(serial_number=self.config.left_odrive.serial)
+            self.initialize_odrive(self.odrive_left)
+            self.get_logger().info("Found left ODrive")
+
+            self.get_logger().info(f"Finding right ODrive (serial number {self.config.right_odrive.serial})...")
+            self.odrive_right = odrive.find_any(serial_number=self.config.right_odrive.serial)
+            self.initialize_odrive(self.odrive_right)
+            self.get_logger().info("Found right ODrive")
+            return True
+        except Exception as e:
+            self.get_logger().fatal(f"Failed to initialize ODrive: {e}")
+            return False
+
+    def cmd_vel_callback(self, msg: Twist) -> None:
         if not self.is_robot_enabled():
             self.get_logger().warning("Robot disabled", throttle_duration_sec=2.0)
             self.set_motor_rps(0.0, 0.0)
@@ -41,7 +48,7 @@ class OdriveDriver(Node):
         left_rps, right_rps = self.config.twist_to_motor_rps(msg.linear.x, msg.angular.z)
         self.set_motor_rps(left_rps, right_rps)
 
-    def publish_enc_vel(self):
+    def publish_enc_vel(self) -> None:
         left_motor_rps, right_motor_rps = self.get_motor_rps()
         linear_mps, angular_radps = self.config.motor_rps_to_twist(left_motor_rps, right_motor_rps)
 
@@ -61,7 +68,13 @@ class OdriveDriver(Node):
         )
 
     def initialize_odrive(self, odrv) -> None:
-        odrv.axis0.requested_state = AxisState.CLOSED_LOOP_CONTROL
+        odrv.clear_errors()
+        try:
+            odrive.utils.request_state(odrv.axis0, AxisState.CLOSED_LOOP_CONTROL)
+        except Exception as e:
+            if ODriveError.DC_BUS_UNDER_VOLTAGE in ODriveError(odrv.axis0.active_errors):
+                raise RuntimeError("EStop is engaged") from e
+            raise
         odrv.axis0.controller.config.control_mode = ControlMode.VELOCITY_CONTROL
 
     def set_motor_rps(self, left_motor_rps: float, right_motor_rps: float) -> None:
@@ -82,6 +95,10 @@ class OdriveDriver(Node):
 def main() -> None:
     rclpy.init()
     node = OdriveDriver()
+
+    if not node.init():
+        return
+
     try:
         rclpy.spin(node)
     finally:

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
@@ -17,11 +17,14 @@ class OdriveDriver(Node):
 
         self.config = utils.config.load(self, OdriveDriverConfig)
 
+        self.watchdog_triggered = False
+
         self.create_subscription(Twist, "cmd_vel", self.cmd_vel_callback, 10)
 
         self.publisher = self.create_publisher(TwistWithCovarianceStamped, "enc_vel", 10)
 
-        self.create_timer(self.config.sample_time_s, self.publish_enc_vel)
+        self.create_timer(self.config.publish_period_s, self.publish_enc_vel)
+        self.watchdog_timer = self.create_timer(self.config.cmd_vel_timeout_s, self.watchdog_callback)
 
     def init(self) -> bool:
         try:
@@ -40,6 +43,9 @@ class OdriveDriver(Node):
             return False
 
     def cmd_vel_callback(self, msg: Twist) -> None:
+        self.watchdog_timer.reset()
+        self.watchdog_triggered = False
+
         if not self.is_robot_enabled():
             self.get_logger().warning("Robot disabled", throttle_duration_sec=2.0)
             self.set_motor_rps(0.0, 0.0)
@@ -47,6 +53,13 @@ class OdriveDriver(Node):
 
         left_rps, right_rps = self.config.twist_to_motor_rps(msg.linear.x, msg.angular.z)
         self.set_motor_rps(left_rps, right_rps)
+
+    def watchdog_callback(self) -> None:
+        if not self.watchdog_triggered:
+            self.get_logger().error("cmd_vel timed out, stopping robot")
+            self.watchdog_triggered = True
+
+        self.set_motor_rps(0.0, 0.0)
 
     def publish_enc_vel(self) -> None:
         left_motor_rps, right_motor_rps = self.get_motor_rps()
@@ -89,6 +102,7 @@ class OdriveDriver(Node):
             with open(self.config.estop_file_path) as f:
                 return f.read().strip() != "1"  # only "1" stops the robot, everything else is enabled
         except Exception:
+            self.get_logger().error("EStop file not found", throttle_duration_sec=30.0)
             return True  # if the e-stop file doesn't exist / is corrupted we assume e-stop is off
 
 

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
@@ -98,8 +98,9 @@ class OdriveDriverConfig:
         right_odrive: Hardware identification and polarity for the right ODrive unit.
         geometry: Drivetrain geometry.
         covariance: Dynamic covariance model for the published twist estimate.
-        sample_time_s: Period of the encoder publish timer (s).
+        publish_period_s: Period of the encoder publish timer (s).
         timestamp_delay_s: Amount subtracted from the publish timestamp to compensate read and processing latency (s).
+        cmd_vel_timeout_s: Maximum age of a cmd_vel command before motors are zeroed (s).
         frame_id: TF frame ID of the robot base, attached to the published twist header.
         estop_file_path: Path to the e-stop flag file. A value of "1" disables motor output.
     """
@@ -108,16 +109,19 @@ class OdriveDriverConfig:
     right_odrive: OdriveConfig
     geometry: GeometryConfig
     covariance: CovarianceConfig
-    sample_time_s: float = 0.01
+    publish_period_s: float = 0.01
     timestamp_delay_s: float = 0.0
+    cmd_vel_timeout_s: float = 0.5
     frame_id: str = "base_link"
     estop_file_path: Path = Path("/tmp/estop_value.txt")
 
     def __post_init__(self) -> None:
-        if self.sample_time_s <= 0:
-            raise ValueError("OdriveDriverConfig: sample_time_s must be > 0")
+        if self.publish_period_s <= 0:
+            raise ValueError("OdriveDriverConfig: publish_period_s must be > 0")
         if self.timestamp_delay_s < 0:
             raise ValueError("OdriveDriverConfig: timestamp_delay_s must be >= 0")
+        if self.cmd_vel_timeout_s <= 0:
+            raise ValueError("OdriveDriverConfig: cmd_vel_timeout_s must be > 0")
 
     def twist_covariance(self, linear_mps: float, angular_radps: float) -> list[float]:
         linear_variance_dynamic = self.covariance.linear_variance_gain * (linear_mps**2)


### PR DESCRIPTION
Closes #20 

## What has changed
Add periodic safety checks in odrive_driver for most recent cmd_vel time

## Testing plan
Tested in lab with maverick by publishing a single cmd_vel. The robot stops after 0.5 seconds which is the configured watchdog time