### PR TITLE
Fix gps_origin_initializer amid new vectornav changes

### DIFF
--- a/src/bringup/README.md
+++ b/src/bringup/README.md
@@ -25,8 +25,8 @@ course is used when no `course` argument is provided. See `bringup/courses/defau
 
 ## gps_origin_calculator.launch.py
 Computes and records the GPS datum for a course. Run this once with the robot stationary at the start position before
-an autonomous run. Starts the VectorNav driver, collects samples for 60–90 seconds, writes the median lat/lon/alt into
-the course's `gps.json`, then shuts down both nodes automatically.
+an autonomous run. Collects GPS samples, writes the median lat/lon/alt into the course's `gps.json`, then shuts down
+automatically.
 
 ```
 ros2 launch bringup gps_origin_calculator.launch.py [course:=<course>]
@@ -35,8 +35,8 @@ ros2 launch bringup gps_origin_calculator.launch.py [course:=<course>]
 ### Parameters
 - `course`: Course profile in `courses/` whose `gps.json` will be updated, default `default`
 
-### Published Topics
-- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix from VectorNav INS
+### Subscribed Topics
+- `gps/raw` (`sensor_msgs/NavSatFix`) - Raw GPS fix (e.g. from VectorNav INS)
 
 
 ## base.launch.py

--- a/src/bringup/launch/gps_origin_calculator.launch.py
+++ b/src/bringup/launch/gps_origin_calculator.launch.py
@@ -1,16 +1,39 @@
-from bringup.launch_utils import bringup_share, load_frames
+from bringup.launch_utils import bringup_share, get_package_share_directory, load_frames
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, EmitEvent, OpaqueFunction, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
-from launch.substitutions import LaunchConfiguration
+from launch.substitutions import Command, LaunchConfiguration
 from launch_ros.actions import Node
+from launch_ros.parameter_descriptions import ParameterValue
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
     frames = load_frames()
     course = LaunchConfiguration("course").perform(context)
-    share = bringup_share()
+    urdf = f"{get_package_share_directory('maverick_description')}/urdf/maverick.xacro"
+
+    # fmt: off
+    robot_description = ParameterValue(
+        Command(
+            [
+                "xacro ", urdf,
+                " base_frame_id:=", frames["base_frame"],
+                " imu_name:=", frames["imu_frame"].removesuffix("_link"),
+                " gnss_a_name:=", frames["gnss_a_frame"].removesuffix("_link"),
+                " gnss_b_name:=", frames["gnss_b_frame"].removesuffix("_link"),
+            ]
+        ), value_type=str,
+    )
+    # fmt: on
+
+    robot_state_publisher_node = Node(
+        package="robot_state_publisher",
+        executable="robot_state_publisher",
+        name="robot_state_publisher",
+        output="screen",
+        parameters=[{"robot_description": robot_description}],
+    )
 
     gps_driver_node = Node(
         package="vectornav_driver",
@@ -18,8 +41,12 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         name="vectornav_driver",
         output="screen",
         parameters=[
-            f"{share}/config/sensors/vectornav.yaml",
+            f"{bringup_share()}/config/hardware/vectornav.yaml",
+            {"imuFrameId": frames["imu_frame"]},
             {"insFrameId": frames["base_frame"]},
+            {"gnssAFrameId": frames["gnss_a_frame"]},
+            {"gnssBFrameId": frames["gnss_b_frame"]},
+            {"mapFrameId": frames["map_frame"]},
         ],
         remappings=[
             ("vectornav/raw/navsatfix", "gps/raw"),
@@ -30,7 +57,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         package="gps_origin_calculator",
         executable="gps_origin_calculator",
         output="screen",
-        parameters=[{"output_file": f"{share}/courses/{course}/gps.json"}],
+        parameters=[{"output_file": f"{bringup_share()}/courses/{course}/gps.json"}],
         remappings=[("gps", "gps/raw")],
     )
 
@@ -41,7 +68,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         )
     )
 
-    return [gps_driver_node, gps_origin_node, shutdown_on_completion]
+    return [robot_state_publisher_node, gps_driver_node, gps_origin_node, shutdown_on_completion]
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/src/bringup/launch/gps_origin_calculator.launch.py
+++ b/src/bringup/launch/gps_origin_calculator.launch.py
@@ -1,57 +1,14 @@
-from bringup.launch_utils import bringup_share, get_package_share_directory, load_frames
+from bringup.launch_utils import bringup_share
 from launch import LaunchDescription, LaunchDescriptionEntity
 from launch.actions import DeclareLaunchArgument, EmitEvent, OpaqueFunction, RegisterEventHandler
 from launch.event_handlers import OnProcessExit
 from launch.events import Shutdown
-from launch.substitutions import Command, LaunchConfiguration
+from launch.substitutions import LaunchConfiguration
 from launch_ros.actions import Node
-from launch_ros.parameter_descriptions import ParameterValue
 
 
 def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
-    frames = load_frames()
     course = LaunchConfiguration("course").perform(context)
-    urdf = f"{get_package_share_directory('maverick_description')}/urdf/maverick.xacro"
-
-    # fmt: off
-    robot_description = ParameterValue(
-        Command(
-            [
-                "xacro ", urdf,
-                " base_frame_id:=", frames["base_frame"],
-                " imu_name:=", frames["imu_frame"].removesuffix("_link"),
-                " gnss_a_name:=", frames["gnss_a_frame"].removesuffix("_link"),
-                " gnss_b_name:=", frames["gnss_b_frame"].removesuffix("_link"),
-            ]
-        ), value_type=str,
-    )
-    # fmt: on
-
-    robot_state_publisher_node = Node(
-        package="robot_state_publisher",
-        executable="robot_state_publisher",
-        name="robot_state_publisher",
-        output="screen",
-        parameters=[{"robot_description": robot_description}],
-    )
-
-    gps_driver_node = Node(
-        package="vectornav_driver",
-        executable="vectornav_driver",
-        name="vectornav_driver",
-        output="screen",
-        parameters=[
-            f"{bringup_share()}/config/hardware/vectornav.yaml",
-            {"imuFrameId": frames["imu_frame"]},
-            {"insFrameId": frames["base_frame"]},
-            {"gnssAFrameId": frames["gnss_a_frame"]},
-            {"gnssBFrameId": frames["gnss_b_frame"]},
-            {"mapFrameId": frames["map_frame"]},
-        ],
-        remappings=[
-            ("vectornav/raw/navsatfix", "gps/raw"),
-        ],
-    )
 
     gps_origin_node = Node(
         package="gps_origin_calculator",
@@ -68,7 +25,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         )
     )
 
-    return [robot_state_publisher_node, gps_driver_node, gps_origin_node, shutdown_on_completion]
+    return [gps_origin_node, shutdown_on_completion]
 
 
 def generate_launch_description() -> LaunchDescription:

--- a/src/localization/gps_origin_calculator/gps_origin_calculator/gps_origin_calculator.py
+++ b/src/localization/gps_origin_calculator/gps_origin_calculator/gps_origin_calculator.py
@@ -23,9 +23,11 @@ class GpsOriginCalculator(Node):
         self.done = False
 
         self.get_logger().info(
-            f"Collecting GNSS samples for datum. Keep robot STILL.\n"
+            f"\n"
+            f"Collecting GNSS samples for datum. Timing will start when the first valid sample is received.\n"
             f"Policy: min_samples={self.config.min_samples_required}, max_horizontal_stdev={self.config.max_horizontal_stdev_m}m,\n"
             f"        min_duration={self.config.min_sample_duration_s}s, max_duration={self.config.max_sample_duration_s}s\n"
+            f"Keep robot STILL."
         )
 
     def gps_callback(self, msg: NavSatFix) -> None:
@@ -48,6 +50,9 @@ class GpsOriginCalculator(Node):
                 f"Dropping GPS msg with high horizontal stdev: {horizontal_stdev} > {self.config.max_horizontal_stdev_m}"
             )
             return
+
+        if len(self.samples) == 0:
+            self.get_logger().info("Received first valid GPS sample, starting collection timer.")
 
         self.samples.append(msg)
 

--- a/src/localization/gps_origin_calculator/gps_origin_calculator/gps_origin_calculator_config.py
+++ b/src/localization/gps_origin_calculator/gps_origin_calculator/gps_origin_calculator_config.py
@@ -1,3 +1,4 @@
+import math
 from dataclasses import dataclass
 from pathlib import Path
 
@@ -17,7 +18,7 @@ class GpsOriginCalculatorConfig:
     min_samples_required: int = 3000
     min_sample_duration_s: float = 60.0
     max_sample_duration_s: float = 90.0
-    max_horizontal_stdev_m: float = 1.0
+    max_horizontal_stdev_m: float = math.sqrt(2)
     output_file: Path = Path("")
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## What has changed
1. Make target stdev sqrt(2) instead of 1 to better accommodate GPS accuracy (we only need to be within ~1.5m from the GPS waypoint instead since the robot is around 0.5m in radius)
2. Add a log when the first GPS data is collected to better estimate duration needed to run
3. Publish URDF in the launch file as it is needed for the vectornav node to run
4. Use correct frame id and config directory 

## Testing plan
Tested on Maverick