### PR TITLE
Add acceleration limits and controller gains to odrive config

### DIFF
--- a/src/bringup/config/hardware/odrive_driver.yaml
+++ b/src/bringup/config/hardware/odrive_driver.yaml
@@ -15,6 +15,15 @@ odrive_driver:
       wheel_diameter_m: 0.18423
       gear_ratio: 18.888888888888889  # 170 / 9
 
+    # ODrive axis controller parameters (all in SI / robot-frame units)
+    controller:
+      vel_gain: 0.08
+      vel_integrator_gain: 0.0
+      vel_integrator_limit: 0.0
+      vel_limit_mps: 3.0
+      accel_limit_mps2: 3.0
+      inertia: 0.0                 # Nm / (m/s²)
+
     # Dynamic covariance model (variance scales with speed)
     covariance:
       linear_variance_static: 1.0e-6
@@ -28,7 +37,5 @@ odrive_driver:
     # Subtracted from publish timestamp to compensate for read/processing latency (s)
     timestamp_delay_s: 0.0
 
-    # Maximum linear acceleration for the ODrive velocity ramp (m/s²)
-    accel_limit_mps2: 3.0
 
     estop_file_path: "/tmp/estop_value.txt"

--- a/src/bringup/config/hardware/odrive_driver.yaml
+++ b/src/bringup/config/hardware/odrive_driver.yaml
@@ -28,4 +28,7 @@ odrive_driver:
     # Subtracted from publish timestamp to compensate for read/processing latency (s)
     timestamp_delay_s: 0.0
 
+    # Maximum linear acceleration for the ODrive velocity ramp (m/s²)
+    accel_limit_mps2: 3.0
+
     estop_file_path: "/tmp/estop_value.txt"

--- a/src/bringup/config/hardware/odrive_driver.yaml
+++ b/src/bringup/config/hardware/odrive_driver.yaml
@@ -37,5 +37,4 @@ odrive_driver:
     # Subtracted from publish timestamp to compensate for read/processing latency (s)
     timestamp_delay_s: 0.0
 
-
     estop_file_path: "/tmp/estop_value.txt"

--- a/src/hardware/odrive_driver/README.md
+++ b/src/hardware/odrive_driver/README.md
@@ -19,6 +19,7 @@ covariance
 | `publish_period_s` | `float` | `0.01` | Period (s) of the encoder publish timer |
 | `cmd_vel_timeout_s` | `float` | `0.5` | Max age of a `cmd_vel` command before motors are zeroed (s) |
 | `timestamp_delay_s` | `float` | `0.0` | Subtracted from the publish timestamp to compensate read and processing latency (s) |
+| `accel_limit_mps2` | `float` | `3.0` | Maximum linear acceleration applied via ODrive velocity ramp (m/s²) |
 | `frame_id` | `str` | `"base_link"` | TF frame ID attached to the published twist header |
 | `estop_file_path` | `Path` | `/tmp/estop_value.txt` | Path to the e-stop flag file |
 

--- a/src/hardware/odrive_driver/README.md
+++ b/src/hardware/odrive_driver/README.md
@@ -19,9 +19,16 @@ covariance
 | `publish_period_s` | `float` | `0.01` | Period (s) of the encoder publish timer |
 | `cmd_vel_timeout_s` | `float` | `0.5` | Max age of a `cmd_vel` command before motors are zeroed (s) |
 | `timestamp_delay_s` | `float` | `0.0` | Subtracted from the publish timestamp to compensate read and processing latency (s) |
-| `accel_limit_mps2` | `float` | `3.0` | Maximum linear acceleration applied via ODrive velocity ramp (m/s²) |
 | `frame_id` | `str` | `"base_link"` | TF frame ID attached to the published twist header |
 | `estop_file_path` | `Path` | `/tmp/estop_value.txt` | Path to the e-stop flag file |
+
+### ODrive Units
+Each ODrive is identified by its USB serial number and a polarity correction. `left_odrive` and `right_odrive` each take the same parameters:
+
+| Parameter | Type | Description |
+|---|---|---|
+| `serial` | `str` | USB serial number of the ODrive unit (find with `odrivetool`) |
+| `polarity` | `int` | Sign correction mapping motor-native direction to robot-forward (`1` or `-1`) |
 
 ### Geometry
 | Parameter | Type | Default | Description |
@@ -29,6 +36,18 @@ covariance
 | `track_width_m` | `float` | `0.764` | Distance between left and right wheel contact points (m) |
 | `wheel_diameter_m` | `float` | `0.18423` | Diameter of each drive wheel (m) |
 | `gear_ratio` | `float` | `170/9 ≈ 18.89` | Motor-to-wheel gear ratio (motor revolutions per wheel revolution) |
+
+### Controller
+All parameters are specified in SI / robot-frame units and converted to motor-native units before being written to the ODrive.
+
+| Parameter | Type | Default | Description |
+|---|---|---|---|
+| `vel_gain` | `float` | `0.08` | Velocity controller proportional gain (A / (m/s)) |
+| `vel_integrator_gain` | `float` | `0.0` | Velocity controller integrator gain (A / (m/s · s)) |
+| `vel_integrator_limit` | `float` | `0.0` | Integrator output clamp (A); `0.0` disables the limit |
+| `vel_limit_mps` | `float` | `3.0` | Motor velocity hard limit (m/s); trips an ODrive error if exceeded |
+| `accel_limit_mps2` | `float` | `3.0` | Maximum linear acceleration via ODrive velocity ramp (m/s²) |
+| `inertia` | `float` | `0.0` | Feed-forward inertia compensation (Nm / (m/s²)) |
 
 ### Covariance
 Variance scales with speed to reflect increased uncertainty at higher velocities:

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
@@ -90,7 +90,7 @@ class OdriveDriver(Node):
             raise
         odrv.axis0.controller.config.control_mode = ControlMode.VELOCITY_CONTROL
         odrv.axis0.controller.config.input_mode = InputMode.VEL_RAMP
-        odrv.axis0.controller.config.vel_ramp_rate = 100.0
+        odrv.axis0.controller.config.vel_ramp_rate = self.config.accel_limit_motor_rps_per_s
 
     def set_motor_rps(self, left_motor_rps: float, right_motor_rps: float) -> None:
         self.odrive_left.axis0.controller.input_vel = left_motor_rps

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
@@ -3,7 +3,7 @@ import odrive.utils
 import rclpy
 import utils.config
 from geometry_msgs.msg import Twist, TwistWithCovariance, TwistWithCovarianceStamped, Vector3
-from odrive.enums import AxisState, ControlMode, ODriveError
+from odrive.enums import AxisState, ControlMode, InputMode, ODriveError
 from rclpy.duration import Duration
 from rclpy.node import Node
 from std_msgs.msg import Header
@@ -89,6 +89,8 @@ class OdriveDriver(Node):
                 raise RuntimeError("EStop is engaged") from e
             raise
         odrv.axis0.controller.config.control_mode = ControlMode.VELOCITY_CONTROL
+        odrv.axis0.controller.config.input_mode = InputMode.VEL_RAMP
+        odrv.axis0.controller.config.vel_ramp_rate = 100.0
 
     def set_motor_rps(self, left_motor_rps: float, right_motor_rps: float) -> None:
         self.odrive_left.axis0.controller.input_vel = left_motor_rps

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
@@ -90,7 +90,12 @@ class OdriveDriver(Node):
             raise
         odrv.axis0.controller.config.control_mode = ControlMode.VELOCITY_CONTROL
         odrv.axis0.controller.config.input_mode = InputMode.VEL_RAMP
-        odrv.axis0.controller.config.vel_ramp_rate = self.config.accel_limit_motor_rps_per_s
+        odrv.axis0.controller.config.vel_gain = self.config.controller.vel_gain
+        odrv.axis0.controller.config.vel_integrator_gain = self.config.controller.vel_integrator_gain
+        odrv.axis0.controller.config.vel_integrator_limit = self.config.controller.vel_integrator_limit
+        odrv.axis0.controller.config.vel_limit = self.config.vel_limit_motor
+        odrv.axis0.controller.config.vel_ramp_rate = self.config.vel_ramp_rate_motor
+        odrv.axis0.controller.config.inertia = self.config.inertia_motor
 
     def set_motor_rps(self, left_motor_rps: float, right_motor_rps: float) -> None:
         self.odrive_left.axis0.controller.input_vel = left_motor_rps

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
@@ -61,8 +61,8 @@ class GeometryConfig:
 class ControllerConfig:
     """ODrive axis controller parameters.
 
-    vel_gain, vel_integrator_gain, vel_integrator_limit, and inertia map directly to ODrive
-    controller config fields after unit conversion from SI to motor-native units.
+    vel_gain, vel_integrator_gain, vel_integrator_limit, and inertia map directly to ODrive controller config fields
+    after unit conversion from SI to motor-native units.
 
     Attributes:
         vel_gain: Velocity controller proportional gain (A / (m/s)).

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
@@ -101,6 +101,7 @@ class OdriveDriverConfig:
         publish_period_s: Period of the encoder publish timer (s).
         timestamp_delay_s: Amount subtracted from the publish timestamp to compensate read and processing latency (s).
         cmd_vel_timeout_s: Maximum age of a cmd_vel command before motors are zeroed (s).
+        accel_limit_mps2: Maximum linear acceleration applied via ODrive velocity ramp (m/s²).
         frame_id: TF frame ID of the robot base, attached to the published twist header.
         estop_file_path: Path to the e-stop flag file. A value of "1" disables motor output.
     """
@@ -112,6 +113,7 @@ class OdriveDriverConfig:
     publish_period_s: float = 0.01
     timestamp_delay_s: float = 0.0
     cmd_vel_timeout_s: float = 0.5
+    accel_limit_mps2: float = 3.0
     frame_id: str = "base_link"
     estop_file_path: Path = Path("/tmp/estop_value.txt")
 
@@ -122,6 +124,12 @@ class OdriveDriverConfig:
             raise ValueError("OdriveDriverConfig: timestamp_delay_s must be >= 0")
         if self.cmd_vel_timeout_s <= 0:
             raise ValueError("OdriveDriverConfig: cmd_vel_timeout_s must be > 0")
+        if self.accel_limit_mps2 <= 0:
+            raise ValueError("OdriveDriverConfig: accel_limit_mps2 must be > 0")
+
+    @property
+    def accel_limit_motor_rps_per_s(self) -> float:
+        return self.accel_limit_mps2 * self.geometry.motor_rps_per_wheel_mps
 
     def twist_covariance(self, linear_mps: float, angular_radps: float) -> list[float]:
         linear_variance_dynamic = self.covariance.linear_variance_gain * (linear_mps**2)

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver_config.py
@@ -58,6 +58,44 @@ class GeometryConfig:
 
 
 @dataclass(frozen=True)
+class ControllerConfig:
+    """ODrive axis controller parameters.
+
+    vel_gain, vel_integrator_gain, vel_integrator_limit, and inertia map directly to ODrive
+    controller config fields after unit conversion from SI to motor-native units.
+
+    Attributes:
+        vel_gain: Velocity controller proportional gain (A / (m/s)).
+        vel_integrator_gain: Velocity controller integrator gain (A / (m/s * s)).
+        vel_integrator_limit: Integrator output clamp (A). 0.0 disables the limit.
+        vel_limit_mps: Motor velocity hard limit (m/s). Trips an error if exceeded.
+        accel_limit_mps2: Maximum linear acceleration applied via ODrive velocity ramp (m/s²).
+        inertia: Feed-forward inertia compensation (Nm / (m/s²)).
+    """
+
+    vel_gain: float = 0.08
+    vel_integrator_gain: float = 0.0
+    vel_integrator_limit: float = 0.0
+    vel_limit_mps: float = 3.0
+    accel_limit_mps2: float = 3.0
+    inertia: float = 0.0
+
+    def __post_init__(self) -> None:
+        if self.vel_gain < 0:
+            raise ValueError("ControllerConfig: vel_gain must be >= 0")
+        if self.vel_integrator_gain < 0:
+            raise ValueError("ControllerConfig: vel_integrator_gain must be >= 0")
+        if self.vel_integrator_limit < 0:
+            raise ValueError("ControllerConfig: vel_integrator_limit must be >= 0")
+        if self.vel_limit_mps <= 0:
+            raise ValueError("ControllerConfig: vel_limit_mps must be > 0")
+        if self.accel_limit_mps2 <= 0:
+            raise ValueError("ControllerConfig: accel_limit_mps2 must be > 0")
+        if self.inertia < 0:
+            raise ValueError("ControllerConfig: inertia must be >= 0")
+
+
+@dataclass(frozen=True)
 class CovarianceConfig:
     """Dynamic covariance model for the published twist estimate.
 
@@ -97,11 +135,11 @@ class OdriveDriverConfig:
         left_odrive: Hardware identification and polarity for the left ODrive unit.
         right_odrive: Hardware identification and polarity for the right ODrive unit.
         geometry: Drivetrain geometry.
+        controller: ODrive axis controller parameters.
         covariance: Dynamic covariance model for the published twist estimate.
         publish_period_s: Period of the encoder publish timer (s).
         timestamp_delay_s: Amount subtracted from the publish timestamp to compensate read and processing latency (s).
         cmd_vel_timeout_s: Maximum age of a cmd_vel command before motors are zeroed (s).
-        accel_limit_mps2: Maximum linear acceleration applied via ODrive velocity ramp (m/s²).
         frame_id: TF frame ID of the robot base, attached to the published twist header.
         estop_file_path: Path to the e-stop flag file. A value of "1" disables motor output.
     """
@@ -109,11 +147,11 @@ class OdriveDriverConfig:
     left_odrive: OdriveConfig
     right_odrive: OdriveConfig
     geometry: GeometryConfig
+    controller: ControllerConfig
     covariance: CovarianceConfig
     publish_period_s: float = 0.01
     timestamp_delay_s: float = 0.0
     cmd_vel_timeout_s: float = 0.5
-    accel_limit_mps2: float = 3.0
     frame_id: str = "base_link"
     estop_file_path: Path = Path("/tmp/estop_value.txt")
 
@@ -124,12 +162,18 @@ class OdriveDriverConfig:
             raise ValueError("OdriveDriverConfig: timestamp_delay_s must be >= 0")
         if self.cmd_vel_timeout_s <= 0:
             raise ValueError("OdriveDriverConfig: cmd_vel_timeout_s must be > 0")
-        if self.accel_limit_mps2 <= 0:
-            raise ValueError("OdriveDriverConfig: accel_limit_mps2 must be > 0")
 
     @property
-    def accel_limit_motor_rps_per_s(self) -> float:
-        return self.accel_limit_mps2 * self.geometry.motor_rps_per_wheel_mps
+    def vel_ramp_rate_motor(self) -> float:
+        return self.controller.accel_limit_mps2 * self.geometry.motor_rps_per_wheel_mps
+
+    @property
+    def vel_limit_motor(self) -> float:
+        return self.controller.vel_limit_mps * self.geometry.motor_rps_per_wheel_mps
+
+    @property
+    def inertia_motor(self) -> float:
+        return self.controller.inertia / self.geometry.motor_rps_per_wheel_mps
 
     def twist_covariance(self, linear_mps: float, angular_radps: float) -> list[float]:
         linear_variance_dynamic = self.covariance.linear_variance_gain * (linear_mps**2)


### PR DESCRIPTION
Closes #25 
Closes #29 

## What has changed
Set ODrive to VEL_RAMP mode to avoid current spikes. 
Add odrive controller configurations

## Testing plan
Tested on Maverick yesterday (we no longer trip on violent commands). Acceleration limit is tuned via binary search by driving and turning very violently and observing if ODrive trips. 