### PR TITLE
Display stdout during colcon build to expose build errors with ninja

### DIFF
--- a/colcon_defaults.yaml
+++ b/colcon_defaults.yaml
@@ -1,5 +1,7 @@
 build:
   symlink-install: true
+  event-handlers:
+    - console_cohesion+
   cmake-args:
     - -GNinja
     - -DCMAKE_C_COMPILER_LAUNCHER=ccache


### PR DESCRIPTION
Closes #35 

## What has changed
Ninja redirects all build errors from stderr to stdout and `colcon build` by default only displays stderr. This is why we can't see any build errors when we switched to ninja. To show the build errors we add `--event-handler console_cohesion+` to colcon build flags which display stdout after a package is built. 

Solution is taken from here: https://github.com/colcon/colcon-cmake/issues/67#issuecomment-1104434793. This is the related ninja issue https://github.com/ninja-build/ninja/issues/1537 and it doesn't look like they're trying to fix this on either end. There *are* some fixes in forks out there but they are generally old and not upstreamed so it's not worth it for us to separately maintain

This does add a lot of extra noise when building but given the above I don't think there is a better solution. The other alternative is switching back to make or to another build system. I couldn't find a good alternative and we do see good performance improvements with ninja, and given that we may want to migrate more of our compute-heavy nodes to C++ I think it is worth it to keep ninja. 

## Testing plan
Tested on my computer