### PR TITLE
Update odrive serial number, limit velocity to 5mph

### DIFF
--- a/src/bringup/config/hardware/odrive_driver.yaml
+++ b/src/bringup/config/hardware/odrive_driver.yaml
@@ -2,7 +2,7 @@ odrive_driver:
   ros__parameters:
     # Serial numbers of the left and right ODrive units
     left_odrive:
-      serial: "395534753331"
+      serial: "002190760F3E"
       polarity: 1
 
     right_odrive:
@@ -20,7 +20,7 @@ odrive_driver:
       vel_gain: 0.08
       vel_integrator_gain: 0.0
       vel_integrator_limit: 0.0
-      vel_limit_mps: 3.0
+      vel_limit_mps: 2.2
       accel_limit_mps2: 3.0
       inertia: 0.0                 # Nm / (m/s²)
 


### PR DESCRIPTION
## What has changed
1. Left ODrive serial number changed after firmware update. This updates it to the new value
2. Limit maverick max velocity to 5 mph as per IGVC rules (the actual speed is dictated by path tracking, this is just the physical limit)

## Testing plan
Tested on robot