### PR TITLE
Lower and tune Stanley controller, lower controller speed

### DIFF
--- a/src/bringup/config/teleop/teleop_ps4.yaml
+++ b/src/bringup/config/teleop/teleop_ps4.yaml
@@ -11,14 +11,14 @@ teleop_twist_joy:
     scale_linear:
       x: 1.2
     scale_linear_turbo:
-      x: 1.8
+      x: 1.5
 
     axis_angular:
       yaw: 3
     scale_angular:
-      yaw: 2.0
+      yaw: 1.0
     scale_angular_turbo:
-      yaw: 2.0
+      yaw: 1.5
 
     enable_button: 5 # R1 shoulder button
     enable_turbo_button: 4  # L1 shoulder button

--- a/src/bringup/config/teleop/teleop_xbox.yaml
+++ b/src/bringup/config/teleop/teleop_xbox.yaml
@@ -11,14 +11,14 @@ teleop_twist_joy:
     scale_linear:
       x: 1.2
     scale_linear_turbo:
-      x: 1.8
+      x: 1.5
 
     axis_angular:
       yaw: 3
     scale_angular:
-      yaw: 2.0
+      yaw: 1.0
     scale_angular_turbo:
-      yaw: 2.0
+      yaw: 1.5
 
     enable_button: 5 # RB shoulder button
     enable_turbo_button: 4  # LB shoulder button

--- a/src/navigation/path_tracking/path_tracking/path_tracking_config.py
+++ b/src/navigation/path_tracking/path_tracking/path_tracking_config.py
@@ -52,13 +52,13 @@ class StanleyConfig:
         curvature_lookahead_m: Arclength ahead of the projection over which heading change is accumulated (m).
     """
 
-    target_speed_mps: float = 1.8
-    cross_track_gain: float = 0.5
-    front_offset_m: float = 1.0
+    target_speed_mps: float = 1.35
+    cross_track_gain: float = 0.6
+    front_offset_m: float = 0.85
     max_steer_rad: float = 1.2
-    max_angular_speed_radps: float = 2.0
+    max_angular_speed_radps: float = 1.0
     goal_tolerance_m: float = 0.3
-    max_lateral_accel_mps2: float = 0.5
+    max_lateral_accel_mps2: float = 1.0
     curvature_lookahead_m: float = 1.5
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## What has changed
1. Turns out we can't really sustain 4mph + 2 radps turn with Stanley due to wheel slip. Lowered to 3mph and tuned accordingly
2. Lowered teleop max speed to 3.5mph which is tested to be fine with human control for turbo

## Testing plan
Tested with robot