### PR TITLE
Stream commands constantly for led_driver

### DIFF
--- a/src/hardware/led_driver/led_driver/led_driver.py
+++ b/src/hardware/led_driver/led_driver/led_driver.py
@@ -98,12 +98,10 @@ class LedDriver(Node):
         if not self.serial.is_open:
             return
 
-        if value == self.last_sent:
-            return
-
         try:
             self.serial.write(f"{value}\n".encode())
-            self.get_logger().info(f"Sent: {value}")
+            if value != self.last_sent:
+                self.get_logger().info(f"Sent: {value}")
             self.last_sent = value
         except serial.SerialException as e:
             self.get_logger().error(f"Serial communication error: {e}")


### PR DESCRIPTION
## What has changed
Currently the led driver only send values when the colors should be changed. This means that if the driver exits, the led will be stuck on the latest value which is not correct. We added a detection on the firmware end so that if streamed command from the driver is lost, it will set the led to a default color. This changes the led to stream data constantly to accomodate this. 

## Testing plan
Tested on maverick