### PR TITLE
Ctrievel/ramp state

### DIFF
--- a/src/bringup/launch/core.launch.py
+++ b/src/bringup/launch/core.launch.py
@@ -49,6 +49,7 @@ def generate_launch_description() -> LaunchDescription:
                     ("state", "state"),
                     ("state/set_no_mans_land", "state/set_no_mans_land"),
                     ("state/set_recovery", "state/set_recovery"),
+                    ("state/set_ramp", "state/set_ramp"),
                 ],
             ),
             Node(

--- a/src/bringup/launch/navigation.launch.py
+++ b/src/bringup/launch/navigation.launch.py
@@ -43,6 +43,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
             ("fromLL", "fromLL"),
             ("state/set_recovery", "state/set_recovery"),
             ("state/set_no_mans_land", "state/set_no_mans_land"),
+            ("state/set_ramp", "state/set_ramp"),
             ("goal", "goal"),
             ("waypoint", "waypoint"),
             ("goal_selection_debug", "goal_selection_debug"),

--- a/src/core/state_machine/README.md
+++ b/src/core/state_machine/README.md
@@ -34,7 +34,6 @@ In code, use `utils.qos.LATCHED`. In RViz, set the topic's **Durability Policy**
 - `state/set_ramp` (`std_srvs/SetBool`) - Enable or disable ramp mode
 - `state/set_recovery` (`std_srvs/SetBool`) - Enable or disable recovery mode
 
-
 ## Example Usage
 ```bash
 ros2 topic echo /state # Observe current state

--- a/src/core/state_machine/README.md
+++ b/src/core/state_machine/README.md
@@ -4,10 +4,11 @@ machine exposes services for state transitions and publishes the robot state to 
 to and react accordingly.
 
 ## States
-There are three mutually exclusive states:
+There are four mutually exclusive states:
 - **`normal`** – default operating mode  
 - **`no_mans_land`** – no mans land-specific behavior enabled  
-- **`recovery`** – recovery / fault handling mode  
+- **`ramp`** – ramp specific behavior enabled
+- **`recovery`** – recovery / fault handling mode 
 
 1. State priority is fixed and deterministic: recovery > no_mans_land > normal
 2. States are published only on state changes
@@ -15,7 +16,7 @@ There are three mutually exclusive states:
 4. Late-joining subscribers immediately receive the most recent state
 
 ## Published Topics
-- `state` (`std_msgs/String`) - The current robot state as one of `"normal"`, `"no_mans_land"`, or `"recovery"`
+- `state` (`std_msgs/String`) - The current robot state as one of `"normal"`, `"no_mans_land"`, `ramp`, or `"recovery"`
 
 The `state` topic uses a non-default QoS profile:
 | Setting | Value | Effect |
@@ -30,7 +31,9 @@ In code, use `utils.qos.LATCHED`. In RViz, set the topic's **Durability Policy**
 
 ## Services
 - `state/set_no_mans_land` (`std_srvs/SetBool`) - Enable or disable no_mans_land mode
+- `state/set_ramp` (`std_srvs/SetBool`) - Enable or disable ramp mode
 - `state/set_recovery` (`std_srvs/SetBool`) - Enable or disable recovery mode
+
 
 ## Example Usage
 ```bash

--- a/src/core/state_machine/state_machine/state_machine.py
+++ b/src/core/state_machine/state_machine/state_machine.py
@@ -66,8 +66,9 @@ class StateMachine(Node):
 
         self.recovery_enabled = req.data
         res.success = True
-        self.get_logger().info(res.message + f" (no_mans_land_enabled={self.no_mans_land_enabled})")
-        self.get_logger().info(res.message + f" (ramp_enabled={self.ramp_enabled})")
+        self.get_logger().info(
+            f"{res.message} (no_mans_land_enabled={self.no_mans_land_enabled}, ramp_enabled={self.ramp_enabled})"
+        )
         self.publish_state_if_changed(reason="state/set_recovery")
         return res
 
@@ -79,8 +80,9 @@ class StateMachine(Node):
 
         self.no_mans_land_enabled = req.data
         res.success = True
-        self.get_logger().info(res.message + f" (recovery_enabled={self.recovery_enabled})")
-        self.get_logger().info(res.message + f" (ramp_enabled={self.ramp_enabled})")
+        self.get_logger().info(
+            f"{res.message} (recovery_enabled={self.recovery_enabled}), (ramp_enabled={self.ramp_enabled})"
+        )
         self.publish_state_if_changed(reason="state/set_no_mans_land")
         return res
 
@@ -92,8 +94,9 @@ class StateMachine(Node):
 
         self.ramp_enabled = req.data
         res.success = True
-        self.get_logger().info(res.message + f" (recovery_enabled={self.recovery_enabled})")
-        self.get_logger().info(res.message + f" (no_mans_land_enabled={self.no_mans_land_enabled})")
+        self.get_logger().info(
+            f"{res.message} (recovery_enabled={self.recovery_enabled}, no_mans_land_enabled={self.no_mans_land_enabled})"
+        )
         self.publish_state_if_changed(reason="state/set_ramp")
         return res
 

--- a/src/core/state_machine/state_machine/state_machine.py
+++ b/src/core/state_machine/state_machine/state_machine.py
@@ -11,6 +11,7 @@ class State(str, Enum):
     NORMAL = "normal"
     NO_MANS_LAND = "no_mans_land"
     RECOVERY = "recovery"
+    RAMP = "ramp"
 
 
 class StateMachine(Node):
@@ -29,6 +30,10 @@ class StateMachine(Node):
         self.set_recovery_service = self.create_service(SetBool, "state/set_recovery", self.set_recovery_callback)
         self.recovery_enabled: bool = False
 
+        #as a fun side effect of me not knowing LED modes, the LEDS will turn rainbow in ramp mode. Happy (early) pride!
+        self.set_ramp_service = self.create_service(SetBool, "state/set_ramp", self.set_ramp_callback)
+        self.ramp_enabled: bool = False
+
         self.publish_state_if_changed(reason="init")
 
     def compute_state(self) -> State:
@@ -37,6 +42,9 @@ class StateMachine(Node):
 
         if self.no_mans_land_enabled:
             return State.NO_MANS_LAND
+
+        if self.ramp_enabled:
+            return State.RAMP
 
         return State.NORMAL
 
@@ -60,6 +68,7 @@ class StateMachine(Node):
         self.recovery_enabled = req.data
         res.success = True
         self.get_logger().info(res.message + f" (no_mans_land_enabled={self.no_mans_land_enabled})")
+        self.get_logger().info(res.message + f" (ramp_enabled={self.ramp_enabled})")
         self.publish_state_if_changed(reason="state/set_recovery")
         return res
 
@@ -72,7 +81,21 @@ class StateMachine(Node):
         self.no_mans_land_enabled = req.data
         res.success = True
         self.get_logger().info(res.message + f" (recovery_enabled={self.recovery_enabled})")
+        self.get_logger().info(res.message + f" (ramp_enabled={self.ramp_enabled})")
         self.publish_state_if_changed(reason="state/set_no_mans_land")
+        return res
+
+    def set_ramp_callback(self, req: SetBool.Request, res: SetBool.Response) -> SetBool.Response:
+        if req.data == self.ramp_enabled:
+            res.message = f"Ramp already {'enabled' if req.data else 'disabled'}."
+        else:
+            res.message = f"Ramp {'enabled' if req.data else 'disabled'}."
+
+        self.ramp_enabled = req.data
+        res.success = True
+        self.get_logger().info(res.message + f" (recovery_enabled={self.recovery_enabled})")
+        self.get_logger().info(res.message + f" (no_mans_land_enabled={self.no_mans_land_enabled})")
+        self.publish_state_if_changed(reason="state/set_ramp")
         return res
 
 

--- a/src/core/state_machine/state_machine/state_machine.py
+++ b/src/core/state_machine/state_machine/state_machine.py
@@ -30,7 +30,6 @@ class StateMachine(Node):
         self.set_recovery_service = self.create_service(SetBool, "state/set_recovery", self.set_recovery_callback)
         self.recovery_enabled: bool = False
 
-        #as a fun side effect of me not knowing LED modes, the LEDS will turn rainbow in ramp mode. Happy (early) pride!
         self.set_ramp_service = self.create_service(SetBool, "state/set_ramp", self.set_ramp_callback)
         self.ramp_enabled: bool = False
 
@@ -40,11 +39,11 @@ class StateMachine(Node):
         if self.recovery_enabled:
             return State.RECOVERY
 
-        if self.no_mans_land_enabled:
-            return State.NO_MANS_LAND
-
         if self.ramp_enabled:
             return State.RAMP
+
+        if self.no_mans_land_enabled:
+            return State.NO_MANS_LAND
 
         return State.NORMAL
 

--- a/src/hardware/led_driver/README.md
+++ b/src/hardware/led_driver/README.md
@@ -16,6 +16,7 @@ Waits up to `ready_timeout_s` for the Arduino to send `READY` before starting.
 | 2 | `teleop_cmd_vel` received within `teleop_timeout_s` | `1` | Solid blue |
 | 3 | `state` = `normal` | `2` | Flashing blue |
 | 3 | `state` = `no_mans_land` | `3` | Flashing green |
+| 3 | `state` = `ramp` | `6` | Flashing purple |
 | 3 | `state` = `recovery` | `4` | Flashing yellow |
 | 4 | `state` is unknown | `9` | Rainbow |
 

--- a/src/hardware/led_driver/README.md
+++ b/src/hardware/led_driver/README.md
@@ -16,9 +16,9 @@ Waits up to `ready_timeout_s` for the Arduino to send `READY` before starting.
 | 2 | `teleop_cmd_vel` received within `teleop_timeout_s` | `1` | Solid blue |
 | 3 | `state` = `normal` | `2` | Flashing blue |
 | 3 | `state` = `no_mans_land` | `3` | Flashing green |
-| 3 | `state` = `ramp` | `9` | Rainbow |
+| 3 | `state` = `ramp` | `5` | Flashing purple |
 | 3 | `state` = `recovery` | `4` | Flashing yellow |
-| 4 | `state` is unknown | `5` | Flashing purple |
+| 4 | `state` is unknown | `9` | Rainbow |
 
 ## Config Parameters
 | Parameter | Type | Default | Description |

--- a/src/hardware/led_driver/README.md
+++ b/src/hardware/led_driver/README.md
@@ -16,9 +16,9 @@ Waits up to `ready_timeout_s` for the Arduino to send `READY` before starting.
 | 2 | `teleop_cmd_vel` received within `teleop_timeout_s` | `1` | Solid blue |
 | 3 | `state` = `normal` | `2` | Flashing blue |
 | 3 | `state` = `no_mans_land` | `3` | Flashing green |
-| 3 | `state` = `ramp` | `6` | Flashing purple |
+| 3 | `state` = `ramp` | `9` | Rainbow |
 | 3 | `state` = `recovery` | `4` | Flashing yellow |
-| 4 | `state` is unknown | `9` | Rainbow |
+| 4 | `state` is unknown | `5` | Flashing purple |
 
 ## Config Parameters
 | Parameter | Type | Default | Description |

--- a/src/hardware/led_driver/led_driver/led_driver.py
+++ b/src/hardware/led_driver/led_driver/led_driver.py
@@ -19,10 +19,10 @@ class LedDriver(Node):
     LED_STATE: typing.ClassVar[dict[str, int]] = {
         "normal": 2,  # Flashing blue
         "no_mans_land": 3,  # Flashing green
-        "ramp": 5,  # Flashing purple
+        "ramp": 9,  # Rainbow
         "recovery": 4,  # Flashing yellow
     }
-    LED_UNKNOWN = 9  # Rainbow
+    LED_UNKNOWN = 5  # Flashing purple
 
     def __init__(self) -> None:
         super().__init__("led_driver")

--- a/src/hardware/led_driver/led_driver/led_driver.py
+++ b/src/hardware/led_driver/led_driver/led_driver.py
@@ -19,10 +19,10 @@ class LedDriver(Node):
     LED_STATE: typing.ClassVar[dict[str, int]] = {
         "normal": 2,  # Flashing blue
         "no_mans_land": 3,  # Flashing green
-        "ramp": 9,  # Flashing purple
+        "ramp": 5,  # Flashing purple
         "recovery": 4,  # Flashing yellow
     }
-    LED_UNKNOWN = 5  # Rainbow
+    LED_UNKNOWN = 9  # Rainbow
 
     def __init__(self) -> None:
         super().__init__("led_driver")

--- a/src/hardware/led_driver/led_driver/led_driver.py
+++ b/src/hardware/led_driver/led_driver/led_driver.py
@@ -19,6 +19,7 @@ class LedDriver(Node):
     LED_STATE: typing.ClassVar[dict[str, int]] = {
         "normal": 2,  # Flashing blue
         "no_mans_land": 3,  # Flashing green
+        "ramp": 5,  # Flashing purple
         "recovery": 4,  # Flashing yellow
     }
     LED_UNKNOWN = 9  # Rainbow

--- a/src/hardware/led_driver/led_driver/led_driver.py
+++ b/src/hardware/led_driver/led_driver/led_driver.py
@@ -19,10 +19,10 @@ class LedDriver(Node):
     LED_STATE: typing.ClassVar[dict[str, int]] = {
         "normal": 2,  # Flashing blue
         "no_mans_land": 3,  # Flashing green
-        "ramp": 9,  # Rainbow
+        "ramp": 9,  # Flashing purple
         "recovery": 4,  # Flashing yellow
     }
-    LED_UNKNOWN = 5  # Flashing purple
+    LED_UNKNOWN = 5  # Rainbow
 
     def __init__(self) -> None:
         super().__init__("led_driver")

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -136,7 +136,12 @@ class AutonavGoalSelection(Node):
         if waypoint is None:
             return
 
-        if self.robot_pose.point.distance(waypoint) >= self.config.waypoint_reached_threshold_m:
+        distance = self.robot_pose.point.distance(waypoint)
+        if self.current_waypoint_index == len(self.waypoints) - 1 and distance <= self.config.ramp_approach_radius_m:
+            self.get_logger().info("Entering ramp")
+            self.set_ramp_client.call_async(SetBool.Request(data=True))
+
+        if distance >= self.config.waypoint_reached_threshold_m:
             return
 
         if self.waypoints[self.current_waypoint_index].no_mans_land:
@@ -147,13 +152,13 @@ class AutonavGoalSelection(Node):
         self.current_waypoint_index += 1
 
         if self.current_waypoint_index >= len(self.waypoints):
+            self.get_logger().info("Exiting ramp")
+            self.set_ramp_client.call_async(SetBool.Request(data=False))
             self.get_logger().info("Final waypoint reached, stopping navigation")
             # We don't call rclpy.shutdown() here because it causes a deadlock in humble
             # https://github.com/ros2/rclpy/issues/1646
             raise SystemExit(1) from None
-        elif self.current_waypoint_index == len(self.waypoints) - 1:
-            self.get_logger().info("Ramp waypoint reached!")
-            self.set_ramp_client.call_async(SetBool.Request(data=True))
+
         self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
         self.publish_gps_waypoint()
 
@@ -168,7 +173,12 @@ class AutonavGoalSelection(Node):
         if waypoint is None:
             return
 
-        near_waypoint = self.robot_pose.point.distance(waypoint) < self.config.ramp_approach_radius_m if self.state == "ramp" else self.robot_pose.point.distance(waypoint) < self.config.waypoint_approach_radius_m
+        near_waypoint_threshold = (
+            self.config.ramp_approach_radius_m if self.state == "ramp" else self.config.waypoint_approach_radius_m
+        )
+
+        near_waypoint = self.robot_pose.point.distance(waypoint) < near_waypoint_threshold
+
         if near_waypoint or self.state == "no_mans_land":
             self.goal_selector.reset()
             self.goal_publisher.publish(

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -137,8 +137,9 @@ class AutonavGoalSelection(Node):
             return
 
         distance = self.robot_pose.point.distance(waypoint)
-        is_last_waypoint = self.current_waypoint_index == len(self.waypoints) - 1
-        if self.state != "ramp" and is_last_waypoint and distance <= self.config.ramp_approach_radius_m:
+        is_last = self.current_waypoint_index == len(self.waypoints) - 1
+
+        if is_last and self.state != "ramp" and distance <= self.config.ramp_approach_radius_m:
             self.get_logger().info("Entering ramp")
             self.set_ramp_client.call_async(SetBool.Request(data=True))
 
@@ -152,7 +153,7 @@ class AutonavGoalSelection(Node):
 
         self.current_waypoint_index += 1
 
-        if self.current_waypoint_index >= len(self.waypoints):
+        if is_last:
             self.get_logger().info("Exiting ramp")
             self.set_ramp_client.call_async(SetBool.Request(data=False))
             self.get_logger().info("Final waypoint reached, stopping navigation")
@@ -174,13 +175,8 @@ class AutonavGoalSelection(Node):
         if waypoint is None:
             return
 
-        near_waypoint_threshold = (
-            self.config.ramp_approach_radius_m if self.state == "ramp" else self.config.waypoint_approach_radius_m
-        )
-
-        near_waypoint = self.robot_pose.point.distance(waypoint) < near_waypoint_threshold
-
-        if near_waypoint or self.state == "no_mans_land":
+        distance = self.robot_pose.point.distance(waypoint)
+        if distance < self.config.waypoint_approach_radius_m or self.state in ("no_mans_land", "ramp"):
             self.goal_selector.reset()
             self.goal_publisher.publish(
                 PointStamped(

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -48,6 +48,7 @@ class AutonavGoalSelection(Node):
 
         self.set_recovery_client = self.create_client(SetBool, "state/set_recovery")
         self.set_no_mans_land_client = self.create_client(SetBool, "state/set_no_mans_land")
+        self.set_ramp_client = self.create_client(SetBool, "state/set_ramp")
 
         self.create_subscription(Odometry, "odom", self.odom_callback, 10)
         self.create_subscription(OccupancyGrid, "occupancy_grid", self.occupancy_grid_callback, 10)
@@ -150,7 +151,9 @@ class AutonavGoalSelection(Node):
             # We don't call rclpy.shutdown() here because it causes a deadlock in humble
             # https://github.com/ros2/rclpy/issues/1646
             raise SystemExit(1) from None
-
+        elif self.current_waypoint_index == len(self.waypoints) - 1:
+            self.get_logger().info("Ramp waypoint reached!")
+            self.set_ramp_client.call_async(SetBool.Request(data=True))
         self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
         self.publish_gps_waypoint()
 
@@ -165,7 +168,7 @@ class AutonavGoalSelection(Node):
         if waypoint is None:
             return
 
-        near_waypoint = self.robot_pose.point.distance(waypoint) < self.config.waypoint_approach_radius_m
+        near_waypoint = self.robot_pose.point.distance(waypoint) < self.config.ramp_approach_radius_m if self.state == "ramp" else self.robot_pose.point.distance(waypoint) < self.config.waypoint_approach_radius_m
         if near_waypoint or self.state == "no_mans_land":
             self.goal_selector.reset()
             self.goal_publisher.publish(

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -137,7 +137,8 @@ class AutonavGoalSelection(Node):
             return
 
         distance = self.robot_pose.point.distance(waypoint)
-        if self.current_waypoint_index == len(self.waypoints) - 1 and distance <= self.config.ramp_approach_radius_m:
+        is_last_waypoint = self.current_waypoint_index == len(self.waypoints) - 1
+        if self.state != "ramp" and is_last_waypoint and distance <= self.config.ramp_approach_radius_m:
             self.get_logger().info("Entering ramp")
             self.set_ramp_client.call_async(SetBool.Request(data=True))
 

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
@@ -125,6 +125,8 @@ class AutonavGoalSelectionConfig:
         waypoint_reached_threshold_m: Distance (m) within which a waypoint is considered reached.
         waypoint_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal selection is bypassed and
             the waypoint itself is published directly as the goal.
+        ramp_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal selection is bypassed and
+            the waypoint itself is published directly as the goal when the waypoint is the ramp waypoint.
         map_frame_id: TF frame ID for the map coordinate frame.
         world_frame_id: TF frame ID for the world coordinate frame.
         publish_debug: When true, publish a MarkerArray on `goal_selection_debug` showing all rays, the chosen ray, the
@@ -136,6 +138,7 @@ class AutonavGoalSelectionConfig:
     goal_publish_period_s: float = 0.25
     waypoint_reached_threshold_m: float = 1.5
     waypoint_approach_radius_m: float = 5.0
+    ramp_approach_radius_m: float = 12.0
     map_frame_id: str = "map"
     world_frame_id: str = "odom"
     publish_debug: bool = True


### PR DESCRIPTION
Closes #

## What has changed
When the robot is within 12 meters of the ramp waypoint (and only the ramp waypoint), it switches the state machine to ramp mode and selects the waypoint as its goal.
## Testing plan
Make sure that it actually enters ramp state properly on the practice course. Make sure that navigating straight to the waypoint safely crosses the ramp. Tune the ramp approach distance.