### PR TITLE
(1/4 Autonav mission control) Add mission state message

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -104,6 +104,7 @@ module = [
     "tf_transformations.*",
     "tf2_geometry_msgs",
 
+    "maverick_msgs.*",
     "robot_localization.*",
     "pyproj",
     "PyKDL",

--- a/src/core/maverick_msgs/CMakeLists.txt
+++ b/src/core/maverick_msgs/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.5)
+project(maverick_msgs)
+
+find_package(ament_cmake REQUIRED)
+find_package(rosidl_default_generators REQUIRED)
+find_package(geometry_msgs REQUIRED)
+
+rosidl_generate_interfaces(${PROJECT_NAME}
+  "msg/MissionState.msg"
+  DEPENDENCIES geometry_msgs
+)
+
+ament_package()

--- a/src/core/maverick_msgs/msg/MissionState.msg
+++ b/src/core/maverick_msgs/msg/MissionState.msg
@@ -1,0 +1,7 @@
+bool in_recovery             # recovery behavior active; goal selection paused
+bool in_ramp_approach        # within ramp_approach_radius of a ramp_approach waypoint; speed capped
+bool in_no_mans_land         # inside a no man's land zone; extra inflation active
+bool lane_detection_enabled  # false inside no man's land except near zone exit
+bool mission_complete        # final waypoint reached; all navigation should stop
+
+geometry_msgs/PointStamped current_waypoint  # current target waypoint, in map frame

--- a/src/core/maverick_msgs/package.xml
+++ b/src/core/maverick_msgs/package.xml
@@ -1,0 +1,20 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>maverick_msgs</name>
+  <version>0.1.0</version>
+  <description>Custom ROS2 message definitions for Maverick</description>
+  <maintainer email="ryanliao@umich.edu">Ryan Liao</maintainer>
+  <license>Apache-2.0</license>
+
+  <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>rosidl_default_generators</buildtool_depend>
+
+  <depend>geometry_msgs</depend>
+
+  <member_of_group>rosidl_interface_packages</member_of_group>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>


### PR DESCRIPTION
## What has changed
Add a mission state message with all 

Design decisions:
1. Why not have a single state that override each other like in the past
Priority can get a bit complex. We already have no mans land and ramp state and ramp may or may not occur during no mans land. This makes a single node only observing discrete no mans land / ramp state logic hard to reason about

2. Why dedicated message type
There are a point and many bools and we may add more in the future to overfit the IGVC autonat course. At this point I think its more ergonomic to have a single message type than to have 8 publishers

## Testing plan
Code compiles
