### PR TITLE
(3/4 Autonav mission control) Migrate nav stack over to mission control

### DIFF
--- a/src/bringup/courses/default/gps.json
+++ b/src/bringup/courses/default/gps.json
@@ -12,12 +12,12 @@
         {
             "x": 25.2,
             "y": 23.8,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "latitude": 42.29462457,
             "longitude": -83.70792126,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         },
         {
             "x": 0.0,

--- a/src/bringup/courses/igvc_north/gps.json
+++ b/src/bringup/courses/igvc_north/gps.json
@@ -8,7 +8,7 @@
         {
             "latitude": 42.668269722,
             "longitude": -83.219340303,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "latitude": 42.668120644,
@@ -21,11 +21,12 @@
         {
             "latitude": 42.667927706,
             "longitude": -83.219327642,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         },
         {
             "latitude": 42.66815632,
-            "longitude": -83.21891819
+            "longitude": -83.21891819,
+            "ramp_approach": true
         }
     ]
 }

--- a/src/bringup/courses/igvc_south/gps.json
+++ b/src/bringup/courses/igvc_south/gps.json
@@ -8,7 +8,7 @@
         {
             "latitude": 42.667927706,
             "longitude": -83.219327642,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "latitude": 42.668076633,
@@ -21,11 +21,12 @@
         {
             "latitude": 42.668269722,
             "longitude": -83.219340303,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         },
         {
             "latitude": 42.66808296,
-            "longitude": -83.21891701
+            "longitude": -83.21891701,
+            "ramp_approach": true
         }
     ]
 }

--- a/src/bringup/courses/practice_igvc_north/gps.json
+++ b/src/bringup/courses/practice_igvc_north/gps.json
@@ -9,7 +9,7 @@
         {
             "latitude": 42.667960058,
             "longitude": -83.218432656,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "latitude": 42.668085961,
@@ -18,7 +18,7 @@
         {
             "latitude": 42.668211819,
             "longitude": -83.218458733,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         },
         {
             "latitude": 88.888888,

--- a/src/bringup/courses/practice_igvc_south/gps.json
+++ b/src/bringup/courses/practice_igvc_south/gps.json
@@ -9,7 +9,7 @@
         {
             "latitude": 42.668211819,
             "longitude": -83.218458733,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "latitude": 42.668085961,
@@ -18,7 +18,7 @@
         {
             "latitude": 42.667960058,
             "longitude": -83.218432656,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         },
         {
             "latitude": 88.888888,

--- a/src/bringup/courses/test2/gps.json
+++ b/src/bringup/courses/test2/gps.json
@@ -8,7 +8,7 @@
         {
             "x": 30.0,
             "y": 10.0,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "x": 30.0,
@@ -17,7 +17,7 @@
         {
             "x": 30.0,
             "y": 20.0,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         }
     ]
 }

--- a/src/bringup/courses/test4/gps.json
+++ b/src/bringup/courses/test4/gps.json
@@ -8,7 +8,7 @@
         {
             "x": 30.0,
             "y": 10.0,
-            "no_mans_land": true
+            "no_mans_land_enter": true
         },
         {
             "x": 30.0,
@@ -17,7 +17,7 @@
         {
             "x": 30.0,
             "y": 20.0,
-            "no_mans_land": true
+            "no_mans_land_exit": true
         }
     ]
 }

--- a/src/bringup/launch/navigation.launch.py
+++ b/src/bringup/launch/navigation.launch.py
@@ -27,25 +27,36 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
         ],
     )
 
+    autonav_mission_control_node = Node(
+        package="autonav_mission_control",
+        executable="autonav_mission_control",
+        name="autonav_mission_control",
+        parameters=[
+            {"waypoints_file_path": f"{bringup_share()}/courses/{course}/gps.json"},
+            {"map_frame_id": frames["map_frame"]},
+        ],
+        remappings=[
+            ("odom", "odom/global"),
+            ("fromLL", "fromLL"),
+            ("mission_state", "mission_state"),
+            ("request_recovery", "request_recovery"),
+            ("recovery_complete", "recovery_complete"),
+        ],
+    )
+
     autonav_goal_selection_node = Node(
         package="autonav_goal_selection",
         executable="autonav_goal_selection",
         name="autonav_goal_selection",
         parameters=[
-            {"waypoints_file_path": f"{bringup_share()}/courses/{course}/gps.json"},
-            {"map_frame_id": frames["map_frame"]},
             {"world_frame_id": frames["odom_frame"]},
         ],
         remappings=[
             ("occupancy_grid", "occupancy_grid/transformed"),
             ("odom", "odom/local"),
-            ("state", "state"),
-            ("fromLL", "fromLL"),
-            ("state/set_recovery", "state/set_recovery"),
-            ("state/set_no_mans_land", "state/set_no_mans_land"),
-            ("state/set_ramp", "state/set_ramp"),
+            ("mission_state", "mission_state"),
+            ("request_recovery", "request_recovery"),
             ("goal", "goal"),
-            ("waypoint", "waypoint"),
             ("goal_selection_debug", "goal_selection_debug"),
         ],
     )
@@ -100,7 +111,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
 
     shutdown_on_completion = RegisterEventHandler(
         OnProcessExit(
-            target_action=autonav_goal_selection_node,
+            target_action=autonav_mission_control_node,
             on_exit=[EmitEvent(event=Shutdown())],
         )
     )
@@ -112,6 +123,7 @@ def launch_setup(context, *args, **kwargs) -> list[LaunchDescriptionEntity]:
                 path_planning_node,
                 path_smoothing_node,
                 path_tracking_node,
+                autonav_mission_control_node,
                 autonav_goal_selection_node,
                 recovery_behavior_node,
                 shutdown_on_completion,
@@ -136,7 +148,7 @@ def generate_launch_description() -> LaunchDescription:
                 choices=MODES,
                 description=format_mode_description(
                     {
-                        "autonav": "occupancy grid transform + path planning + path smoothing + path tracking + autonav goal selection + recovery",
+                        "autonav": "occupancy grid transform + path planning + path smoothing + path tracking + mission control + autonav goal selection + recovery",
                         "self_drive": "occupancy grid transform + path planning + path smoothing + path tracking + recovery",
                         "nav_test": "occupancy grid transform + path planning + path smoothing + path tracking + recovery",
                     }

--- a/src/bringup/package.xml
+++ b/src/bringup/package.xml
@@ -18,6 +18,7 @@
   <exec_depend>joint_state_publisher</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>autonav_goal_selection</exec_depend>
+  <exec_depend>autonav_mission_control</exec_depend>
   <exec_depend>path_planning</exec_depend>
   <exec_depend>occupancy_grid_transform</exec_depend>
   <exec_depend>path_tracking</exec_depend>

--- a/src/navigation/autonav_goal_selection/README.md
+++ b/src/navigation/autonav_goal_selection/README.md
@@ -1,13 +1,14 @@
 # autonav_goal_selection
-Map waypoint following with local goal selection for autonomous navigation.
+Local goal selection toward the mission's current waypoint for autonomous navigation.
 
 ## How it works
 
 ### The big picture
-The robot is given a list of coarse GPS/map waypoints (think: "go to this field corner, then that one"). The waypoints
-are far apart and don't account for obstacles between them. This node's job is to bridge that gap: every publish period 
-it picks a local goal a few meters ahead that keeps the robot moving toward the current waypoint while staying in 
-drivable space.
+The mission is a list of coarse GPS/map waypoints (think: "go to this field corner, then that one") tracked by 
+`autonav_mission_control`, which publishes the current target waypoint on the latched `mission_state` topic. The 
+waypoints are far apart and don't account for obstacles between them. This node's job is to bridge that gap: every 
+publish period it picks a local goal a few meters ahead that keeps the robot moving toward the current waypoint while 
+staying in drivable space.
 
 ### Step 1 — Ray casting
 Each tick, the node shoots a fan of rays outward from the robot's current position. The fan spans `arc_angle_rad`
@@ -66,67 +67,45 @@ Low `ema_alpha` (default 0.1) means momentum changes slowly; high values make it
 ### Waypoint approach
 When the robot is within `waypoint_approach_radius_m` (default 5 m) of the current waypoint, ray casting is skipped
 entirely and the waypoint itself is published as the goal. This ensures the robot reaches waypoints precisely rather
-than stopping short. Once within `waypoint_reached_threshold_m` (default 1.5m), the waypoint is marked reached and the
-next one becomes active.
+than stopping short. The same bypass applies while `in_no_mans_land` or `in_ramp_approach` is set in the mission state.
+Waypoint advancement itself is handled by `autonav_mission_control`; this node always drives toward whatever
+`current_waypoint` the latest `mission_state` message contains.
 
-## Waypoints File Format
-```json
-{
-    "waypoints": [
-        {"x": 5.0, "y": 0.0},
-        {"latitude": 42.2946, "longitude": -83.7238},
-        {"x": 10.0, "y": 5.0, "no_mans_land": true}
-    ]
-}
-```
-Each waypoint is either map frame `x`/`y` (meters) or GPS `latitude`/`longitude` (converted via `fromLL` at
-startup). Setting `no_mans_land: true` toggles no man's land state when that waypoint is reached.
-
-## State Machine Integration
-This node both reads and writes state via the `state` topic and two service clients.
+## Mission Control Integration
+This node reads mission state from the latched `mission_state` topic published by `autonav_mission_control` (see that 
+package's README for the waypoints file format and state semantics).
 
 **Recovery** is triggered when all rays are shorter than `min_goal_progress_m` (the robot is surrounded by obstacles). 
-The node calls `state/set_recovery true`, resets momentum, and stops publishing goals. The external state machine is 
-responsible for driving the robot out of the stuck situation and calling `state/set_recovery false` when done.
+The node calls the `request_recovery` service, resets momentum, and stops publishing goals while `in_recovery` is set. 
+The recovery behavior node is responsible for driving the robot out of the stuck situation and calling 
+`recovery_complete` when done.
 
-**No-man's land** is toggled each time a waypoint flagged `no_mans_land: true` is reached. The node calls 
-`state/set_no_mans_land` with the new boolean value and logs the transition. No man's land waypoints act as region 
-boundary markers: the first one entering a region sets the flag true, the next one exiting sets it false.
+Goal publishing also stops once `mission_complete` is set.
 
 ## Subscribed Topics
 | Topic | Type | Description |
 |---|---|---|
 | `odom` | `nav_msgs/msg/Odometry` | Robot pose in the world frame |
 | `occupancy_grid` | `nav_msgs/msg/OccupancyGrid` | Local occupancy grid rays are cast through |
-| `state` | `std_msgs/msg/String` | State machine state; `"recovery"` suppresses goal publishing |
+| `mission_state` | `maverick_msgs/msg/MissionState` | Mission state (latched); provides the current waypoint and behavior flags |
 
 ## Published Topics
 | Topic | Type | Description |
 |---|---|---|
 | `goal` | `geometry_msgs/msg/PointStamped` | Selected local goal in the world frame |
-| `waypoint` | `geometry_msgs/msg/PointStamped` | Current map-frame waypoint (latched) |
 | `goal_selection_debug` | `visualization_msgs/msg/MarkerArray` | Ray visualization; only published when `publish_debug` is true |
-
-The `waypoint` topic uses a latched QoS profile (`TRANSIENT_LOCAL`, depth 1). Late-joining subscribers receive the
-current waypoint immediately on connect. Subscribers **must** use a compatible QoS (`TRANSIENT_LOCAL`) or they will
-not receive the message. In code, use `utils.qos.LATCHED`. In RViz, set **Durability Policy** to `Transient Local`.
 
 ## Service Clients
 | Service | Type | Description |
 |---|---|---|
-| `fromLL` | `robot_localization/srv/FromLL` | Converts GPS waypoints to map-frame coordinates at startup |
-| `state/set_recovery` | `std_srvs/srv/SetBool` | Triggers recovery when no drivable goal is found |
-| `state/set_no_mans_land` | `std_srvs/srv/SetBool` | Toggles no-man's-land state when a flagged waypoint is reached |
+| `request_recovery` | `std_srvs/srv/Trigger` | Triggers recovery when no drivable goal is found |
 
 ## Config Parameters (`AutonavGoalSelectionConfig`)
 | Parameter | Type | Default | Description |
 |---|---|---|---|
 | `goal_selection_params` | `GoalSelectionParams` | required | Ray-cast goal selection parameters (see below) |
-| `waypoints_file_path` | `Path` | required | Path to the JSON waypoints file |
-| `goal_publish_period_s` | `float` | `0.25` | Timer period (s) for goal selection and publishing |
-| `waypoint_reached_threshold_m` | `float` | `1.5` | Distance (m) within which a waypoint is considered reached |
+| `goal_publish_period_s` | `float` | `1` | Timer period (s) for goal selection and publishing |
 | `waypoint_approach_radius_m` | `float` | `5.0` | Distance (m) from the waypoint within which ray-casting is bypassed and the waypoint is published directly |
-| `map_frame_id` | `str` | `"map"` | TF frame for map-frame waypoint coordinates |
 | `world_frame_id` | `str` | `"odom"` | TF frame for the world/robot pose coordinates |
 | `publish_debug` | `bool` | `true` | When true, publish the `goal_selection_debug` MarkerArray |
 

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -1,18 +1,14 @@
-import json
-from dataclasses import dataclass
-
 import rclpy
 import tf2_geometry_msgs  # noqa: F401 — registers PointStamped transform
 import tf2_ros
 import utils.config
 import utils.qos
-from geographic_msgs.msg import GeoPoint
 from geometry_msgs.msg import PointStamped, Vector3
+from maverick_msgs.msg import MissionState
 from nav_msgs.msg import OccupancyGrid, Odometry
 from rclpy.node import Node
-from robot_localization.srv import FromLL
-from std_msgs.msg import ColorRGBA, Header, String
-from std_srvs.srv import SetBool
+from std_msgs.msg import ColorRGBA, Header
+from std_srvs.srv import Trigger
 from tf2_ros import TransformException
 from utils.geometry import Point2d, Pose2d
 from utils.world_occupancy_grid import WorldOccupancyGrid
@@ -20,12 +16,6 @@ from visualization_msgs.msg import Marker, MarkerArray
 
 from .autonav_goal_selection_config import AutonavGoalSelectionConfig
 from .autonav_goal_selection_impl import GoalSelector
-
-
-@dataclass(frozen=True)
-class Waypoint:
-    point: Point2d
-    no_mans_land: bool = False
 
 
 class AutonavGoalSelection(Node):
@@ -36,31 +26,22 @@ class AutonavGoalSelection(Node):
 
         self.robot_pose: Pose2d | None = None
         self.grid: WorldOccupancyGrid | None = None
+        self.mission_state: MissionState | None = None
         self.goal_selector = GoalSelector(self.config.goal_selection_params)
-        self.in_no_mans_land: bool = False
-        self.state: str = "normal"
-
-        self.waypoints: list[Waypoint] = self.load_waypoints()
-        self.current_waypoint_index = 0
 
         self.tf_buffer = tf2_ros.Buffer()
         self.tf_listener = tf2_ros.TransformListener(self.tf_buffer, self)
 
-        self.set_recovery_client = self.create_client(SetBool, "state/set_recovery")
-        self.set_no_mans_land_client = self.create_client(SetBool, "state/set_no_mans_land")
-        self.set_ramp_client = self.create_client(SetBool, "state/set_ramp")
+        self.request_recovery_client = self.create_client(Trigger, "request_recovery")
 
         self.create_subscription(Odometry, "odom", self.odom_callback, 10)
         self.create_subscription(OccupancyGrid, "occupancy_grid", self.occupancy_grid_callback, 10)
-        self.create_subscription(String, "state", self.state_callback, utils.qos.LATCHED)
+        self.create_subscription(MissionState, "mission_state", self.mission_state_callback, utils.qos.LATCHED)
 
         self.goal_publisher = self.create_publisher(PointStamped, "goal", 10)
-        self.waypoint_publisher = self.create_publisher(PointStamped, "waypoint", utils.qos.LATCHED)
         self.debug_publisher = self.create_publisher(MarkerArray, "goal_selection_debug", 10)
 
         self.create_timer(self.config.goal_publish_period_s, self.publish_goal)
-
-        self.publish_gps_waypoint()
 
     def odom_callback(self, msg: Odometry) -> None:
         if msg.header.frame_id != self.config.world_frame_id:
@@ -70,7 +51,6 @@ class AutonavGoalSelection(Node):
             return
 
         self.robot_pose = Pose2d.from_ros(msg.pose.pose)
-        self.advance_waypoint_if_reached()
 
     def occupancy_grid_callback(self, msg: OccupancyGrid) -> None:
         if msg.header.frame_id != self.config.world_frame_id:
@@ -81,103 +61,39 @@ class AutonavGoalSelection(Node):
 
         self.grid = WorldOccupancyGrid(msg)
 
-    def state_callback(self, msg: String) -> None:
-        self.state = msg.data
+    def mission_state_callback(self, msg: MissionState) -> None:
+        self.mission_state = msg
 
-    def load_waypoints(self) -> list[Waypoint]:
-        with open(self.config.waypoints_file_path) as f:
-            data = json.load(f)
+    def transform_to_world(self, stamped: PointStamped) -> Point2d | None:
+        # Drop the stamp so tf uses the latest available transform instead of looking up the exact time. Since the state
+        # is only updated on change, the timestamp can get stale which would stop us from getting the latest odom error
+        # corrections
+        stamped = PointStamped(header=Header(frame_id=stamped.header.frame_id), point=stamped.point)
 
-        from_ll_client = self.create_client(FromLL, "fromLL")
-
-        self.get_logger().info("Waiting for fromLL service...")
-        from_ll_client.wait_for_service()
-        self.get_logger().info("fromLL service available, loading waypoints")
-
-        waypoints = []
-        for w in data["waypoints"]:
-            if "latitude" in w:
-                request = FromLL.Request(ll_point=GeoPoint(latitude=w["latitude"], longitude=w["longitude"]))
-                future = from_ll_client.call_async(request)
-                rclpy.spin_until_future_complete(self, future)
-                point = Point2d.from_ros(future.result().map_point)
-            else:
-                point = Point2d(x=float(w["x"]), y=float(w["y"]))
-
-            waypoints.append(Waypoint(point=point, no_mans_land=bool(w.get("no_mans_land", False))))
-
-        return waypoints
-
-    def transform_map_to_world(self, point: Point2d) -> Point2d | None:
         try:
-            stamped = PointStamped(header=Header(frame_id=self.config.map_frame_id), point=point.to_ros())
             return Point2d.from_ros(self.tf_buffer.transform(stamped, self.config.world_frame_id).point)
         except TransformException as e:
             self.get_logger().error(f"TF transform failed: {e}")
             return None
 
-    def publish_gps_waypoint(self) -> None:
-        map_point = self.waypoints[self.current_waypoint_index].point
-        self.get_logger().info(
-            f"Publishing waypoint ({map_point.x:.2f}, {map_point.y:.2f}) in {self.config.map_frame_id} frame"
-        )
-        self.waypoint_publisher.publish(
-            PointStamped(
-                header=Header(frame_id=self.config.map_frame_id, stamp=self.get_clock().now().to_msg()),
-                point=map_point.to_ros(),
-            )
-        )
-
-    def advance_waypoint_if_reached(self) -> None:
-        if self.robot_pose is None or self.current_waypoint_index >= len(self.waypoints):
-            return
-
-        waypoint = self.transform_map_to_world(self.waypoints[self.current_waypoint_index].point)
-        if waypoint is None:
-            return
-
-        distance = self.robot_pose.point.distance(waypoint)
-        is_last = self.current_waypoint_index == len(self.waypoints) - 1
-
-        if is_last and self.state != "ramp" and distance <= self.config.ramp_approach_radius_m:
-            self.get_logger().info("Entering ramp")
-            self.set_ramp_client.call_async(SetBool.Request(data=True))
-
-        if distance >= self.config.waypoint_reached_threshold_m:
-            return
-
-        if self.waypoints[self.current_waypoint_index].no_mans_land:
-            self.in_no_mans_land = not self.in_no_mans_land
-            self.get_logger().info(f"{'Entering' if self.in_no_mans_land else 'Exiting'} no man's land")
-            self.set_no_mans_land_client.call_async(SetBool.Request(data=self.in_no_mans_land))
-
-        self.current_waypoint_index += 1
-
-        if is_last:
-            self.get_logger().info("Exiting ramp")
-            self.set_ramp_client.call_async(SetBool.Request(data=False))
-            self.get_logger().info("Final waypoint reached, looping back")
-            # Our last gps waypoint is collected before the starting line, but for IGVC we must cross the line so we
-            # need to go further than our last gps waypoint. As a workaround we just loop back to the first point which
-            # triggers autonav goal selection mode to drive forward then manually estop
-            self.current_waypoint_index = 0
-
-        self.get_logger().info(f"Waypoint reached, advancing to index {self.current_waypoint_index}")
-        self.publish_gps_waypoint()
-
     def publish_goal(self) -> None:
-        if self.robot_pose is None or self.grid is None or self.current_waypoint_index >= len(self.waypoints):
+        if self.robot_pose is None or self.grid is None or self.mission_state is None:
             return
 
-        if self.state == "recovery":
+        if self.mission_state.in_recovery or self.mission_state.mission_complete:
             return
 
-        waypoint = self.transform_map_to_world(self.waypoints[self.current_waypoint_index].point)
+        waypoint = self.transform_to_world(self.mission_state.current_waypoint)
         if waypoint is None:
             return
 
         distance = self.robot_pose.point.distance(waypoint)
-        if distance < self.config.waypoint_approach_radius_m or self.state in ("no_mans_land", "ramp"):
+        drive_directly_to_waypoint = (
+            distance < self.config.waypoint_approach_radius_m
+            or self.mission_state.in_no_mans_land
+            or self.mission_state.in_ramp_approach
+        )
+        if drive_directly_to_waypoint:
             self.goal_selector.reset()
             self.goal_publisher.publish(
                 PointStamped(
@@ -196,7 +112,7 @@ class AutonavGoalSelection(Node):
         if goal is None:
             self.get_logger().warn("No drivable goal found in occupancy grid")
             self.goal_selector.reset()
-            self.set_recovery_client.call_async(SetBool.Request(data=True))
+            self.request_recovery_client.call_async(Trigger.Request())
             return
 
         self.goal_publisher.publish(

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection_config.py
@@ -1,5 +1,4 @@
 import math
-import pathlib
 from dataclasses import dataclass
 
 from utils.geometry import Rotation2d
@@ -120,33 +119,22 @@ class AutonavGoalSelectionConfig:
 
     Attributes:
         goal_selection_params: Parameters for the ray-cast goal selection algorithm.
-        waypoints_file_path: Path to a JSON file containing the list of map-frame waypoints.
         goal_publish_period_s: How often (seconds) to publish a new local goal.
-        waypoint_reached_threshold_m: Distance (m) within which a waypoint is considered reached.
-        waypoint_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal selection is bypassed and
-            the waypoint itself is published directly as the goal.
-        ramp_approach_radius_m: Distance (m) from the waypoint within which ray-cast goal selection is bypassed and
-            the waypoint itself is published directly as the goal when the waypoint is the ramp waypoint.
-        map_frame_id: TF frame ID for the map coordinate frame.
+        waypoint_approach_radius_m: Distance (m) from the current waypoint within which ray-cast goal selection is
+            bypassed and the waypoint itself is published directly as the goal.
         world_frame_id: TF frame ID for the world coordinate frame.
         publish_debug: When true, publish a MarkerArray on `goal_selection_debug` showing all rays, the chosen ray, the
             chosen endpoint, and the waypoint direction.
     """
 
     goal_selection_params: GoalSelectionParams
-    waypoints_file_path: pathlib.Path
     goal_publish_period_s: float = 1
-    waypoint_reached_threshold_m: float = 0.5
     waypoint_approach_radius_m: float = 5.0
-    ramp_approach_radius_m: float = 12.0
-    map_frame_id: str = "map"
     world_frame_id: str = "odom"
     publish_debug: bool = True
 
     def __post_init__(self) -> None:
         if self.goal_publish_period_s <= 0:
             raise ValueError("AutonavGoalSelectionConfig: goal_publish_period_s must be > 0")
-        if self.waypoint_reached_threshold_m <= 0:
-            raise ValueError("AutonavGoalSelectionConfig: waypoint_reached_threshold_m must be > 0")
         if self.waypoint_approach_radius_m < 0:
             raise ValueError("AutonavGoalSelectionConfig: waypoint_approach_radius_m must be >= 0")

--- a/src/navigation/autonav_goal_selection/package.xml
+++ b/src/navigation/autonav_goal_selection/package.xml
@@ -8,14 +8,13 @@
   <license>Apache-2.0</license>
 
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>geographic_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>maverick_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
-  <exec_depend>robot_localization</exec_depend>
   <exec_depend>utils</exec_depend>
   <exec_depend>visualization_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>

--- a/src/navigation/recovery_behavior/README.md
+++ b/src/navigation/recovery_behavior/README.md
@@ -1,15 +1,16 @@
 # recovery_behavior
 
-State-machine-driven recovery node. When the robot enters the `recovery` state it sweeps left/right using an ultrasonic 
-sensor to find a clear path, then backs up.
+Mission-control-driven recovery node. When `in_recovery` becomes true the robot sweeps left/right using an ultrasonic
+sensor to find a clear path, then backs up. When the maneuver finishes it calls `recovery_complete` so mission control
+can clear `in_recovery`.
 
 Reads ultrasonic distance from `/dev/ultrasonic` at 9600 baud.
 
 ## Subscribed Topics
-- `state` (`std_msgs/String`) — triggers recovery when value is `"recovery"`
+- `mission_state` (`maverick_msgs/MissionState`) — triggers recovery when `in_recovery` transitions to true
 
 ## Published Topics
 - `recovery_cmd_vel` (`geometry_msgs/Twist`)
 
 ## Service Clients
-- `state/set_recovery` (`std_srvs/SetBool`) — signals recovery end back to the nav stack
+- `recovery_complete` (`std_srvs/Trigger`) — signals recovery end back to mission control

--- a/src/navigation/recovery_behavior/package.xml
+++ b/src/navigation/recovery_behavior/package.xml
@@ -8,8 +8,8 @@
   <license>Apache-2.0</license>
 
   <exec_depend>rclpy</exec_depend>
-  <exec_depend>std_msgs</exec_depend>
   <exec_depend>geometry_msgs</exec_depend>
+  <exec_depend>maverick_msgs</exec_depend>
   <exec_depend>std_srvs</exec_depend>
   <exec_depend>python3-serial</exec_depend>
   <exec_depend>utils</exec_depend>

--- a/src/navigation/recovery_behavior/recovery_behavior/recovery_executable.py
+++ b/src/navigation/recovery_behavior/recovery_behavior/recovery_executable.py
@@ -4,10 +4,10 @@ import rclpy
 import serial
 import utils.qos
 from geometry_msgs.msg import Twist
+from maverick_msgs.msg import MissionState
 from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
-from std_msgs.msg import String
-from std_srvs.srv import SetBool
+from std_srvs.srv import Trigger
 
 recovery_executable = None
 THRESHOLD_DISTANCE = 60  # centimeters, distance needed to start backing up
@@ -32,11 +32,12 @@ class RecoveryExecutable(Node):
         self.arduino_timer = self.create_timer(0.05, self.updateArduinoReading)
 
         self.subscription = self.create_subscription(
-            String,
-            "state",
+            MissionState,
+            "mission_state",
             self.listener_callback,
             utils.qos.LATCHED,
         )
+        self.last_in_recovery = False
 
         self.ultrasoundReading = 2000.0
         self.ultrasoundReadingHistory = []  # Store last 5 readings for median filter
@@ -60,10 +61,10 @@ class RecoveryExecutable(Node):
             self.get_logger().error("Could not open serial port")
             self.arduino = None
 
-        self.cli = self.create_client(SetBool, "state/set_recovery")
+        self.cli = self.create_client(Trigger, "recovery_complete")
         while not self.cli.wait_for_service(timeout_sec=1.0):
             self.get_logger().info("service not available, waiting again...")
-        self.req = SetBool.Request()
+        self.req = Trigger.Request()
 
     # This gets in the arduino reading and updates the self.ultrasoundReading, which is where we use the ultrasound readigns in the rest of the code
     def updateArduinoReading(self):
@@ -97,8 +98,12 @@ class RecoveryExecutable(Node):
                 self.end_recovery()
 
     def listener_callback(self, msg):
-        if msg.data == "recovery":
+        # Even though the mission state is latched its possible something else triggers a new state while we're already
+        # in recovery (i.e. recovering into end of no man's land). To avoid triggering multiple recoveries we store the
+        # current recovery status and guard by it
+        if msg.in_recovery and not self.last_in_recovery:
             self.begin_recovery()
+        self.last_in_recovery = msg.in_recovery
 
     # This funciton is called periodically. It actually publishes the velocity messages and has the logic of whether to call the function that just drives teh robot backwards or call the sweep function
     def velocity_publishing(self):
@@ -167,7 +172,7 @@ class RecoveryExecutable(Node):
         self.publisher_Twist.publish(msg)
         self.state = "noPublishing"
         self.get_logger().info("recovery ended")
-        self.send_request(False)
+        self.send_request()
 
     def begin_recovery(self):
         self.state = "beginRecovery"
@@ -195,8 +200,7 @@ class RecoveryExecutable(Node):
             self.state = "startSweep"
 
     # This should publish the message back to nav
-    def send_request(self, set_recovery):
-        self.req.data = set_recovery
+    def send_request(self):
         future = self.cli.call_async(self.req)
         future.add_done_callback(self.handle_response)
 


### PR DESCRIPTION
## What has changed
Launch autonav_mission_control and migrate its direct collaborators off the state machine so it is functional:
1. `autonav_goal_selection` no longer loads waypoints or tracks state; it drives toward `mission_state.current_waypoint` and requests recovery via the `request_recovery` service
2. `recovery_behavior` triggers on the in_recovery flag and reports back through the `recovery_complete` service
3. Course gps.json files migrated to the new waypoint schema (no_mans_land_enter/exit pairs, explicit ramp_approach on the final waypoint to preserve the previous last-waypoint ramp behavior)

## Testing plan
Tested in simulation