### PR TITLE
Update gain for path planning

### DIFF
--- a/src/navigation/path_planning/README.md
+++ b/src/navigation/path_planning/README.md
@@ -20,6 +20,6 @@ Transformed to `frame_id` via TF if necessary.
 | Parameter | Default | Description |
 |---|---|---|
 | `frame_id` | `odom` | TF frame ID for the occupancy grid, odometry, goal, and published path |
-| `max_unknown_forward_m` | `2.0` | How far forward of the robot (m) unknown cells are treated as traversable by A* |
-| `max_unknown_sideways_m` | `1.0` | How far sideways of the robot (m) unknown cells are treated as traversable by A* |
+| `max_unknown_forward_m` | `5.0` | How far forward of the robot (m) unknown cells are treated as traversable by A* |
+| `max_unknown_sideways_m` | `2.5` | How far sideways of the robot (m) unknown cells are treated as traversable by A* |
 | `line_of_sight_step_m` | `0.05` | Step size (m) for sampling segments during string-pulling line-of-sight checks. Smaller values give more accurate collision checking at the cost of more computation |

--- a/src/navigation/path_planning/path_planning/path_planning_config.py
+++ b/src/navigation/path_planning/path_planning/path_planning_config.py
@@ -18,8 +18,8 @@ class PathPlanningConfig:
     """
 
     frame_id: str = "odom"
-    max_unknown_forward_m: float = 2.0
-    max_unknown_sideways_m: float = 1.0
+    max_unknown_forward_m: float = 5.0
+    max_unknown_sideways_m: float = 2.5
     line_of_sight_step_m: float = 0.05
 
     def __post_init__(self) -> None:


### PR DESCRIPTION
## What has changed
Increase the area where we treat unknown as drivable to the full grid for path planning. CV treats blips as unknown so this ensures that we can still traverse through transient blips

## Testing plan
Tested at comp