### PR TITLE
Support defaults overrides for nested dataclasses for config.load

### DIFF
--- a/src/core/utils/README.md
+++ b/src/core/utils/README.md
@@ -13,6 +13,11 @@ Mapping rules:
 is not supplied in YAML.
 - If the field has no default, the parameter is required; `load()` will raise if it is missing / unset.
 - Nested dataclasses are supported and map to nested parameter dictionaries.
+- A nested dataclass field may carry a default instance (a frozen instance directly, or any instance via
+`field(default_factory=...)`). Its attribute values become the per-leaf defaults for that subtree, taking precedence
+over the nested dataclass's own field defaults and making the whole subtree optional. YAML keys still override
+individual leaves. This allows several fields of the same nested dataclass type to have different defaults, e.g.
+`fast: SpeedParams = SpeedParams(max_mps=2.0)` and `slow: SpeedParams = SpeedParams(max_mps=0.5)`.
 
 Supported field types:
 - Primitives: `bool`, `int`, `float`, `str`, `bytes`

--- a/src/core/utils/test/test_config.py
+++ b/src/core/utils/test/test_config.py
@@ -29,7 +29,7 @@ class MockNode:
 
 
 def test_load_required_param_success():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         rate: int
 
@@ -41,7 +41,7 @@ def test_load_required_param_success():
 
 
 def test_load_required_param_missing_raises():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         rate: int
 
@@ -51,7 +51,7 @@ def test_load_required_param_missing_raises():
 
 
 def test_load_default_is_used_if_missing():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         rate: int = 20
 
@@ -62,7 +62,7 @@ def test_load_default_is_used_if_missing():
 
 
 def test_load_default_overridden_if_present():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         rate: int = 20
 
@@ -73,7 +73,7 @@ def test_load_default_overridden_if_present():
 
 
 def test_load_default_factory():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         ids: list[int] = field(default_factory=lambda: [1, 2, 3])
 
@@ -83,19 +83,17 @@ def test_load_default_factory():
     assert config.ids == [1, 2, 3]
 
 
-@dataclass
-class Inner:
-    gain: float = 0.5
-    name: str = "abc"
-
-
-@dataclass
-class Outer:
-    inner: Inner
-    rate: int = 10
-
-
 def test_load_nested_dataclass():
+    @dataclass(frozen=True)
+    class Inner:
+        gain: float = 0.5
+        name: str = "abc"
+
+    @dataclass(frozen=True)
+    class Config:
+        inner: Inner
+        rate: int = 10
+
     node = MockNode(
         initial={
             "inner.gain": 1.25,
@@ -103,15 +101,105 @@ def test_load_nested_dataclass():
         }
     )
 
-    config = load(node, Outer)
+    config = load(node, Config)
 
     assert config.rate == 42
     assert config.inner.gain == 1.25
     assert config.inner.name == "abc"
 
 
+def test_load_nested_default_instance():
+
+    @dataclass(frozen=True)
+    class Inner:
+        gain: float = 0.5
+        name: str = "abc"
+
+    @dataclass(frozen=True)
+    class Config:
+        inner: Inner = Inner(gain=2.0)
+
+    node = MockNode(initial={})
+    config = load(node, Config)
+
+    assert config.inner.gain == 2.0
+    assert config.inner.name == "abc"
+
+
+def test_load_nested_default_instance_overridden_by_params():
+    @dataclass(frozen=True)
+    class Inner:
+        gain: float = 0.5
+        name: str = "abc"
+
+    @dataclass(frozen=True)
+    class Config:
+        inner: Inner = Inner(gain=2.0)
+
+    node = MockNode(initial={"inner.gain": 3.5})
+    config = load(node, Config)
+
+    assert config.inner.gain == 3.5
+    assert config.inner.name == "abc"
+
+
+def test_load_nested_default_factory_makes_required_leaf_optional():
+    @dataclass(frozen=True)
+    class InnerWithRequired:
+        gain: float
+        name: str = "abc"
+
+    @dataclass(frozen=True)
+    class Config:
+        inner: InnerWithRequired = field(default_factory=lambda: InnerWithRequired(gain=1.5))
+
+    node = MockNode(initial={})
+    config = load(node, Config)
+
+    assert config.inner.gain == 1.5
+    assert config.inner.name == "abc"
+
+
+def test_load_nested_without_default_instance_keeps_leaf_required():
+    @dataclass(frozen=True)
+    class InnerWithRequired:
+        gain: float
+        name: str = "abc"
+
+    @dataclass(frozen=True)
+    class Config:
+        inner: InnerWithRequired
+
+    node = MockNode(initial={})
+    with pytest.raises(RuntimeError, match=r"Required parameter 'inner.gain' not set"):
+        load(node, Config)
+
+
+def test_load_nested_default_instance_recurses():
+    @dataclass(frozen=True)
+    class Inner:
+        gain: float = 0.5
+        name: str = "abc"
+
+    @dataclass(frozen=True)
+    class Middle:
+        inner: Inner = Inner()
+        scale: float = 1.0
+
+    @dataclass(frozen=True)
+    class Config:
+        middle: Middle = Middle(inner=Inner(gain=4.0), scale=2.0)
+
+    node = MockNode(initial={"middle.inner.name": "xyz"})
+    config = load(node, Config)
+
+    assert config.middle.scale == 2.0
+    assert config.middle.inner.gain == 4.0
+    assert config.middle.inner.name == "xyz"
+
+
 def test_load_bytes():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         data: bytes
 
@@ -122,7 +210,7 @@ def test_load_bytes():
 
 
 def test_load_list():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         ids: list[int]
 
@@ -133,7 +221,7 @@ def test_load_list():
 
 
 def test_load_path_required():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         log_dir: Path
 
@@ -145,7 +233,7 @@ def test_load_path_required():
 
 
 def test_load_path_default():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         log_dir: Path = Path("/var/log")
 
@@ -157,7 +245,7 @@ def test_load_path_default():
 
 
 def test_load_path_default_overridden():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         log_dir: Path = Path("/var/log")
 
@@ -168,7 +256,7 @@ def test_load_path_default_overridden():
 
 
 def test_load_unsupported_type_raises():
-    @dataclass
+    @dataclass(frozen=True)
     class Config:
         value: tuple
 

--- a/src/core/utils/utils/config.py
+++ b/src/core/utils/utils/config.py
@@ -11,6 +11,10 @@ Mapping rules:
   the default is used when the key is not supplied in YAML.
 - If the field has no default, the parameter is required; `load()` will raise if it is missing / unset.
 - Nested dataclasses are supported and map to nested parameter dictionaries.
+- A nested dataclass field may carry a default instance (a frozen instance directly, or any instance via
+  `field(default_factory=...)`). Its attribute values become the per-leaf defaults for that subtree, taking
+  precedence over the nested dataclass's own field defaults and making the whole subtree optional. YAML keys
+  still override individual leaves.
 
 Supported field types:
 - Primitives: `bool`, `int`, `float`, `str`, `bytes`
@@ -60,9 +64,8 @@ class Planner(Node):
 ```
 """
 
-import sys
 from collections.abc import Callable
-from dataclasses import MISSING, dataclass, fields, is_dataclass
+from dataclasses import MISSING, Field, dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any, Generic, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
 
@@ -122,7 +125,16 @@ def _literal_entry(field_type: Any, key: str) -> _Entry[Any, Any]:
     return _Entry(base.raw_type, base.ros_type, deserialize, base.serialize)
 
 
-def load(node: Node, cls: type[T], _prefix: str = "") -> T:
+def _field_default(f: "Field[Any]") -> Any:
+    """The field's declared default, or MISSING if the field is required."""
+    if f.default is not MISSING:
+        return f.default
+    if f.default_factory is not MISSING:
+        return f.default_factory()
+    return MISSING
+
+
+def load(node: Node, cls: type[T]) -> T:
     """
     Load ROS 2 parameters from `node` into a dataclass instance of type `cls`.
     Args:
@@ -133,54 +145,45 @@ def load(node: Node, cls: type[T], _prefix: str = "") -> T:
     Raises:
         RuntimeError: If a required parameter (field without a default) is missing or unset.
     """
+    return _load(node, cls, prefix="", defaults=None)
+
+
+def _load(node: Node, cls: type[T], prefix: str, defaults: Any) -> T:
     if not is_dataclass(cls):
         raise TypeError(f"{cls!r} is not a dataclass type")
 
     try:
-        frame = sys._getframe(1)
-        type_hints = get_type_hints(cls, globalns=frame.f_globals, localns=frame.f_locals)
-    except (NameError, AttributeError, ValueError):
-        try:
-            type_hints = get_type_hints(cls)
-        except Exception:
-            type_hints = {}
+        type_hints = get_type_hints(cls)
+    except Exception:
+        type_hints = {}
 
     kwargs: dict[str, Any] = {}
 
     for f in fields(cls):
-        key = f"{_prefix}{f.name}"
+        key = f"{prefix}{f.name}"
         field_type = type_hints.get(f.name, f.type)
-        try:
-            if is_dataclass(field_type):
-                kwargs[f.name] = load(node, cast(type, field_type), _prefix=f"{key}.")
-                continue
-        except (TypeError, AttributeError):
-            pass
+        # A default instance passed down from the enclosing field overrides the dataclass's own field defaults
+        default_value = getattr(defaults, f.name) if defaults is not None else _field_default(f)
+
+        if is_dataclass(field_type):
+            nested_defaults = default_value if default_value is not MISSING else None
+            kwargs[f.name] = _load(node, cast(type, field_type), prefix=f"{key}.", defaults=nested_defaults)
+            continue
 
         entry = _literal_entry(field_type, key) if get_origin(field_type) is Literal else _ENTRIES.get(field_type)
 
         if entry is None:
-            raise TypeError(
-                f"Parameter '{key}' has unsupported type {field_type!r}. "
-                f"Supported types: {', '.join(t.__name__ for t in _ENTRIES)}"
-            )
-
-        # fmt: off
-        default_value = (
-            f.default if f.default is not MISSING
-            else f.default_factory() if f.default_factory is not MISSING
-            else MISSING
-        )
-        # fmt: on
+            supported = ", ".join(t.__name__ if isinstance(t, type) else str(t) for t in _ENTRIES)
+            raise TypeError(f"Parameter '{key}' has unsupported type {field_type!r}. Supported types: {supported}")
 
         if default_value is MISSING:
             node.declare_parameter(key, descriptor=ParameterDescriptor(type=entry.ros_type.value))
-            value = node.get_parameter(key).value
-            if value is None:
-                raise RuntimeError(f"Required parameter '{key}' not set for node '{node.get_name()}'")
-            kwargs[f.name] = entry.deserialize(value)
         else:
             node.declare_parameter(key, entry.serialize(default_value))
-            kwargs[f.name] = entry.deserialize(node.get_parameter(key).value)
+
+        value = node.get_parameter(key).value
+        if value is None:
+            raise RuntimeError(f"Required parameter '{key}' not set for node '{node.get_name()}'")
+        kwargs[f.name] = entry.deserialize(value)
 
     return cls(**kwargs)


### PR DESCRIPTION
## What has changed
1. Add support for defaults for nested data classes like this:
```py
@dataclass(frozen=True)
class Inner:
    gain: float = 0.5
    name: str = "abc"

@dataclass(frozen=True)
class Config:
    inner: Inner = Inner(gain=2.0)
```

2. Refactor code slightly to make logic clearer

## Testing plan
Wrote new unit tests, unit test passes. Simulation still runs