### PR TITLE
Improve version compatibility

### DIFF
--- a/.github/workflows/docker-build.yaml
+++ b/.github/workflows/docker-build.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write

--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   lint:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}:latest
       credentials:
@@ -38,5 +38,5 @@ jobs:
       - name: Lint
         shell: bash
         run: |
-          source /opt/ros/humble/setup.bash
+          source /opt/ros/$ROS_DISTRO/setup.bash
           just lint

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -16,7 +16,7 @@ concurrency:
 
 jobs:
   test:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-latest
     container:
       image: ghcr.io/${{ github.repository }}:latest
       credentials:
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           ccache --zero-stats
-          source /opt/ros/humble/setup.bash
+          source /opt/ros/$ROS_DISTRO/setup.bash
           just build
 
       - name: Cache stats
@@ -53,7 +53,7 @@ jobs:
       - name: Test
         shell: bash
         run: |
-          source /opt/ros/humble/setup.bash
+          source /opt/ros/$ROS_DISTRO/setup.bash
           source install/setup.bash
           just test
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,5 @@
-FROM ros:humble
+ARG ROS_DISTRO=humble
+FROM ros:${ROS_DISTRO}
 
 ENV ROS_HOME=/opt/ros_home
 

--- a/scripts/setup_environment.py
+++ b/scripts/setup_environment.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 from common import ROOT, run
 
-ROS_DISTRO = os.environ.get("ROS_DISTRO", "humble")
+ROS_DISTRO = os.environ.get("ROS_DISTRO")
 
 
 def log(msg: str) -> None:
@@ -19,6 +19,10 @@ def note(msg: str) -> None:
 
 
 def main() -> None:
+    if not ROS_DISTRO:
+        print("ROS_DISTRO is not set. Source /opt/ros/<distro>/setup.bash first.", file=sys.stderr)
+        sys.exit(1)
+
     if not Path(f"/opt/ros/{ROS_DISTRO}").exists():
         print(f"ROS not found at /opt/ros/{ROS_DISTRO}", file=sys.stderr)
         sys.exit(1)

--- a/src/core/maverick_msgs/CMakeLists.txt
+++ b/src/core/maverick_msgs/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(maverick_msgs)
 
 find_package(ament_cmake REQUIRED)

--- a/src/hardware/vectornav_driver/CMakeLists.txt
+++ b/src/hardware/vectornav_driver/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(vectornav_driver)
 
 find_package(ament_cmake REQUIRED)

--- a/src/hardware/vectornav_driver/include/transforms.hpp
+++ b/src/hardware/vectornav_driver/include/transforms.hpp
@@ -3,15 +3,14 @@
 #include <algorithm>
 #include <array>
 #include <cmath>
+#include <geometry_msgs/msg/vector3.hpp>
+#include <tf2/LinearMath/Matrix3x3.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2/LinearMath/Vector3.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <vector>
-
-#include "geometry_msgs/msg/vector3.hpp"
-#include "tf2/LinearMath/Matrix3x3.h"
-#include "tf2/LinearMath/Quaternion.h"
-#include "tf2/LinearMath/Vector3.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-#include "vectornav/Implementation/MeasurementDatatypes.hpp"
-#include "vectornav/TemplateLibrary/Matrix.hpp"
+#include <vectornav/Implementation/MeasurementDatatypes.hpp>
+#include <vectornav/TemplateLibrary/Matrix.hpp>
 
 inline geometry_msgs::msg::Vector3 to_vector3(const VN::Vec3f& vector) {
     geometry_msgs::msg::Vector3 out;

--- a/src/hardware/vectornav_driver/include/vectornav_driver.hpp
+++ b/src/hardware/vectornav_driver/include/vectornav_driver.hpp
@@ -1,22 +1,22 @@
 #pragma once
 
 #include <GeographicLib/LocalCartesian.hpp>
+#include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <rclcpp/rclcpp.hpp>
+#include <sensor_msgs/msg/imu.hpp>
+#include <sensor_msgs/msg/nav_sat_fix.hpp>
+#include <std_msgs/msg/float32.hpp>
+#include <std_msgs/msg/float32_multi_array.hpp>
+#include <std_msgs/msg/u_int16.hpp>
+#include <tf2/LinearMath/Quaternion.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_listener.hpp>
 #include <unordered_map>
+#include <vectornav/Interface/Sensor.hpp>
 
-#include "geometry_msgs/msg/twist_with_covariance_stamped.hpp"
-#include "nav_msgs/msg/odometry.hpp"
-#include "rclcpp/rclcpp.hpp"
-#include "sensor_msgs/msg/imu.hpp"
-#include "sensor_msgs/msg/nav_sat_fix.hpp"
-#include "std_msgs/msg/float32.hpp"
-#include "std_msgs/msg/float32_multi_array.hpp"
-#include "std_msgs/msg/u_int16.hpp"
-#include "tf2/LinearMath/Quaternion.h"
-#include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
-#include "tf2_ros/buffer.h"
-#include "tf2_ros/transform_listener.h"
 #include "transforms.hpp"
-#include "vectornav/Interface/Sensor.hpp"
 
 #if __linux__
 #include <fcntl.h>

--- a/src/localization/map_odom_publisher/CMakeLists.txt
+++ b/src/localization/map_odom_publisher/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.16)
 project(map_odom_publisher)
 
 if(NOT CMAKE_CXX_STANDARD)

--- a/src/localization/map_odom_publisher/src/map_odom_publisher.cpp
+++ b/src/localization/map_odom_publisher/src/map_odom_publisher.cpp
@@ -1,16 +1,15 @@
-#include <tf2/LinearMath/Transform.h>
-#include <tf2/exceptions.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_broadcaster.h>
-#include <tf2_ros/transform_listener.h>
-
 #include <chrono>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 #include <memory>
 #include <nav_msgs/msg/odometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <string>
+#include <tf2/LinearMath/Transform.hpp>
+#include <tf2/exceptions.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+#include <tf2_ros/buffer.hpp>
+#include <tf2_ros/transform_broadcaster.hpp>
+#include <tf2_ros/transform_listener.hpp>
 
 class MapOdomPublisher : public rclcpp::Node {
   public:


### PR DESCRIPTION
## What has changed
Prepare for ROS migration by parameterizing version specific code
1. Use `$ROS_DISTRO` instead of hard coding humble
2. Use `ubuntu-latest` for CI (which then loads the docker image of whatever version we should run
3. Replace deprecated `.h` tf2 headers with `.hpp`
4. Bump m inimum cmake version
5. Replace system package includes with <> which is correct and prevent compatibility issues