### PR TITLE
Fix plot_motor_signals.py for odrive_driver

### DIFF
--- a/justfile
+++ b/justfile
@@ -83,8 +83,8 @@ clear-odrive-errors:
     python3 src/hardware/odrive_driver/scripts/clear_odrive_errors.py
 
 # Plot ODrive Iq and velocity (requires odrive_driver running with debug: true)
-plot-odrive:
-    python3 src/hardware/odrive_driver/scripts/plot_motor_signals.py
+plot-odrive *args:
+    python3 src/hardware/odrive_driver/scripts/plot_motor_signals.py {{args}}
 
 # ── VectorNav ──────────────────────────────────────────────────────────────────
 

--- a/src/hardware/odrive_driver/README.md
+++ b/src/hardware/odrive_driver/README.md
@@ -12,6 +12,8 @@ publishes encoder-derived velocity with propagated covariance. Motors are zeroed
 ## Published Topics
 - `enc_vel` (`geometry_msgs/TwistWithCovarianceStamped`) - encoder derived linear/angular velocity with dynamic 
 covariance
+- `odrive_driver/debug` (`std_msgs/Float32MultiArray`) - per-motor Iq and velocity signals, only published when `debug`
+is true: `[l_iq_sp, l_iq_meas, l_vel_sp, l_vel_est, r_iq_sp, r_iq_meas, r_vel_sp, r_vel_est]`. Iq in A, velocity in rps
 
 ## Config Parameters
 | Parameter | Type | Default | Description |
@@ -21,6 +23,7 @@ covariance
 | `timestamp_delay_s` | `float` | `0.0` | Subtracted from the publish timestamp to compensate read and processing latency (s) |
 | `frame_id` | `str` | `"base_link"` | TF frame ID attached to the published twist header |
 | `estop_file_path` | `Path` | `/tmp/estop_value.txt` | Path to the e-stop flag file |
+| `debug` | `bool` | `false` | Whether to publish per-motor Iq and velocity signals on `odrive_driver/debug` |
 
 ### ODrive Units
 Each ODrive is identified by its USB serial number and a polarity correction. `left_odrive` and `right_odrive` each take the same parameters:
@@ -86,3 +89,18 @@ If errors persist or if the scripts can't detect an ODrive, troubleshoot in the 
 3. Run `odrivetool` and see if the official tool is able to detect them
 4. Close the terminal and open a new one
 5. Restart the laptop
+
+### `scripts/plot_motor_signals.py`
+Live-plots left/right Iq setpoint vs measured (A) and velocity setpoint vs estimate (rps) from the
+`odrive_driver/debug` topic. Useful for tuning the velocity controller and diagnosing motor behavior. Requires
+`odrive_driver` to be running with `debug: true` in its config. Unlike the calibration and error-clearing scripts, this
+script reads only the ROS topic and does not hold the USB connection, so it can run alongside the node.
+```bash
+just plot-odrive                              # 500-sample window, 10 Hz redraw
+just plot-odrive --window 1000 --frame-rate 15
+```
+
+| Argument | Default | Description |
+|---|---|---|
+| `--window N` | `500` | Number of samples to display |
+| `--frame-rate HZ` | `10` | Plot redraw rate (Hz) |

--- a/src/hardware/odrive_driver/README.md
+++ b/src/hardware/odrive_driver/README.md
@@ -91,16 +91,10 @@ If errors persist or if the scripts can't detect an ODrive, troubleshoot in the 
 5. Restart the laptop
 
 ### `scripts/plot_motor_signals.py`
-Live-plots left/right Iq setpoint vs measured (A) and velocity setpoint vs estimate (rps) from the
-`odrive_driver/debug` topic. Useful for tuning the velocity controller and diagnosing motor behavior. Requires
-`odrive_driver` to be running with `debug: true` in its config. Unlike the calibration and error-clearing scripts, this
-script reads only the ROS topic and does not hold the USB connection, so it can run alongside the node.
+Live-plots left/right Iq setpoint vs measured (A) and velocity setpoint vs estimate (rps) from the `odrive_driver/debug`
+topic. Useful for tuning the velocity controller and diagnosing motor behavior. Requires `odrive_driver` to be running 
+with `debug: true` in its config.
 ```bash
 just plot-odrive                              # 500-sample window, 10 Hz redraw
 just plot-odrive --window 1000 --frame-rate 15
 ```
-
-| Argument | Default | Description |
-|---|---|---|
-| `--window N` | `500` | Number of samples to display |
-| `--frame-rate HZ` | `10` | Plot redraw rate (Hz) |

--- a/src/hardware/odrive_driver/scripts/calibrate_odrive.py
+++ b/src/hardware/odrive_driver/scripts/calibrate_odrive.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import odrive
 import odrive.utils
 from odrive.enums import AxisState

--- a/src/hardware/odrive_driver/scripts/clear_odrive_errors.py
+++ b/src/hardware/odrive_driver/scripts/clear_odrive_errors.py
@@ -1,4 +1,3 @@
-#!/usr/bin/env python3
 import odrive
 
 

--- a/src/hardware/odrive_driver/scripts/plot_motor_signals.py
+++ b/src/hardware/odrive_driver/scripts/plot_motor_signals.py
@@ -1,16 +1,3 @@
-#!/usr/bin/env python3
-"""
-Live-plot motor current and velocity for both ODrive controllers.
-
-Subscribes to odrive_driver/debug (Float32MultiArray) and displays four real-time plots: left/right Iq setpoint vs
-measured (A), and left/right velocity setpoint vs estimate (rps).
-
-Requires odrive_driver to be running with debug: true in its config.
-
-Usage:
-    just plot-odrive [--window 1000] [--frame-rate 15]
-"""
-
 import argparse
 from collections import deque
 
@@ -68,7 +55,7 @@ class MotorSignalPlotter(Node):
             self.data[key].append(val)
 
     def render(self) -> None:
-        # Once the window is closed its canvas is freed; drawing on it would be a use-after-free in the GUI backend
+        # Once the window is closed its canvas is freed, drawing on it would be a use after free in the GUI backend
         if not plt.fignum_exists(self.fig.number):
             # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
             # https://github.com/ros2/rclpy/issues/1646
@@ -98,6 +85,7 @@ def main() -> None:
 
     rclpy.init()
     node = MotorSignalPlotter(window=args.window, frame_rate=args.frame_rate)
+
     try:
         rclpy.spin(node)
     finally:

--- a/src/hardware/odrive_driver/scripts/plot_motor_signals.py
+++ b/src/hardware/odrive_driver/scripts/plot_motor_signals.py
@@ -2,39 +2,36 @@
 """
 Live-plot motor current and velocity for both ODrive controllers.
 
-Subscribes to /odrive_driver/debug (Float32MultiArray) and displays four
-real-time plots: left/right Iq setpoint vs measured (A), and left/right
-velocity setpoint vs estimate (rps).
+Subscribes to odrive_driver/debug (Float32MultiArray) and displays four real-time plots: left/right Iq setpoint vs
+measured (A), and left/right velocity setpoint vs estimate (rps).
 
 Requires odrive_driver to be running with debug: true in its config.
 
 Usage:
-    just plot-odrive [-- --window 1000]
+    just plot-odrive [--window 1000] [--frame-rate 15]
 """
 
 import argparse
 from collections import deque
 
-import matplotlib.animation as animation
 import matplotlib.pyplot as plt
 import rclpy
 from rclpy.node import Node
 from std_msgs.msg import Float32MultiArray
 
-_FIELDS = ["l_iq_sp", "l_iq_meas", "l_vel_sp", "l_vel_est", "r_iq_sp", "r_iq_meas", "r_vel_sp", "r_vel_est"]
+FIELDS = ["l_iq_sp", "l_iq_meas", "l_vel_sp", "l_vel_est", "r_iq_sp", "r_iq_meas", "r_vel_sp", "r_vel_est"]
 
 
 class MotorSignalPlotter(Node):
-    def __init__(self, window: int):
+    def __init__(self, window: int, frame_rate: float = 10.0):
         super().__init__("odrive_plot")
 
-        self._data: dict[str, deque[float]] = {k: deque(maxlen=window) for k in _FIELDS}
+        self.data: dict[str, deque[float]] = {k: deque(maxlen=window) for k in FIELDS}
 
-        self._fig, axes = plt.subplots(2, 2, sharex=True, figsize=(12, 7))
-        self._fig.suptitle("ODrive diagnostics")
-        self._axes = axes
+        self.fig, self.axes = plt.subplots(2, 2, sharex=True, figsize=(12, 7))
+        self.fig.suptitle("ODrive diagnostics")
 
-        (ax_l_iq, ax_r_iq), (ax_l_vel, ax_r_vel) = axes
+        (ax_l_iq, ax_r_iq), (ax_l_vel, ax_r_vel) = self.axes
         for ax, title in [
             (ax_l_iq, "Left Iq (A)"),
             (ax_r_iq, "Right Iq (A)"),
@@ -54,31 +51,39 @@ class MotorSignalPlotter(Node):
         (l_vel_est,) = ax_l_vel.plot([], [], label="estimate", color="tab:orange")
         (r_vel_sp,) = ax_r_vel.plot([], [], label="setpoint", color="tab:blue")
         (r_vel_est,) = ax_r_vel.plot([], [], label="estimate", color="tab:orange")
-        for ax in axes.flat:
+        for ax in self.axes.flat:
             ax.legend(loc="upper right")
 
-        self._lines = (l_iq_sp, l_iq_meas, r_iq_sp, r_iq_meas, l_vel_sp, l_vel_est, r_vel_sp, r_vel_est)
+        self.lines = (l_iq_sp, l_iq_meas, r_iq_sp, r_iq_meas, l_vel_sp, l_vel_est, r_vel_sp, r_vel_est)
 
-        self.create_subscription(Float32MultiArray, "/odrive_driver/debug", self._on_debug, 10)
+        self.create_subscription(Float32MultiArray, "odrive_driver/debug", self.callback, 100)
+        self.create_timer(1.0 / frame_rate, self.render)
 
-    def _on_debug(self, msg: Float32MultiArray) -> None:
-        for key, val in zip(self._data.keys(), msg.data, strict=True):
-            self._data[key].append(val)
+        plt.tight_layout()
+        plt.ion()
+        plt.show(block=False)
 
-    def update(self, _) -> tuple:
-        rclpy.spin_once(self, timeout_sec=0)
-        xs = range(len(self._data["l_iq_sp"]))
-        for line, key in zip(self._lines, _FIELDS, strict=True):
-            line.set_data(xs, self._data[key])
-        for ax in self._axes.flat:
+    def callback(self, msg: Float32MultiArray) -> None:
+        for key, val in zip(self.data.keys(), msg.data, strict=True):
+            self.data[key].append(val)
+
+    def render(self) -> None:
+        # Once the window is closed its canvas is freed; drawing on it would be a use-after-free in the GUI backend
+        if not plt.fignum_exists(self.fig.number):
+            # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
+            # https://github.com/ros2/rclpy/issues/1646
+            raise SystemExit(0)
+
+        xs = range(len(self.data["l_iq_sp"]))
+        for line, key in zip(self.lines, FIELDS, strict=True):
+            line.set_data(xs, self.data[key])
+
+        for ax in self.axes.flat:
             ax.relim()
             ax.autoscale_view()
-        return self._lines
 
-    def show(self) -> None:
-        self._ani = animation.FuncAnimation(self._fig, self.update, interval=100, blit=False)
-        plt.tight_layout()
-        plt.show()
+        self.fig.canvas.draw_idle()
+        self.fig.canvas.flush_events()
 
 
 def main() -> None:
@@ -86,13 +91,18 @@ def main() -> None:
     parser.add_argument(
         "--window", type=int, default=500, metavar="N", help="number of samples to display (default: 500)"
     )
+    parser.add_argument(
+        "--frame-rate", type=float, default=10.0, metavar="HZ", help="plot redraw rate in Hz (default: 10)"
+    )
     args = parser.parse_args()
 
     rclpy.init()
-    plotter = MotorSignalPlotter(window=args.window)
-    plotter.show()
-    plotter.destroy_node()
-    rclpy.shutdown()
+    node = MotorSignalPlotter(window=args.window, frame_rate=args.frame_rate)
+    try:
+        rclpy.spin(node)
+    finally:
+        node.destroy_node()
+        rclpy.shutdown()
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## What has changed
1. The current plotter is capped at 10hz and discards motor data if the rate is any higher which results in low resolution data. This splits the node into a subscriber which always saves the data and a separate render timer to decouple the two rates
2. Add docs
3. Remove extra `#!/usr/bin/env python3` for odrive_driver scripts since we always run it with python3 specified

## Testing plan
Tested with a fake publisher that publishes sin waves