### PR TITLE
Only wait for service if needed for autonav_mission_control

### DIFF
--- a/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
+++ b/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
@@ -82,8 +82,11 @@ class AutonavMissionControl(Node):
         from_ll_client = self.create_client(FromLL, "fromLL")
         if any("latitude" in w for w in data["waypoints"]):
             self.get_logger().info("Waiting for fromLL service...")
-            if not from_ll_client.wait_for_service(timeout_sec=10.0):
-                self.get_logger().fatal("fromLL service not available after 10s; cannot convert lat/lon waypoints")
+            timeout = self.config.from_ll_service_timeout_s
+            if not from_ll_client.wait_for_service(timeout_sec=timeout):
+                self.get_logger().fatal(
+                    f"fromLL service not available after {timeout:g}s; cannot convert lat/lon waypoints"
+                )
                 raise SystemExit(1)
             self.get_logger().info("fromLL service available, loading waypoints")
 

--- a/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
+++ b/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
@@ -77,14 +77,20 @@ class AutonavMissionControl(Node):
             self.get_logger().fatal(f"{self.config.waypoints_file_path} has an empty waypoints list")
             raise SystemExit(1)
 
+        # Only the lat/lon waypoints need fromLL service conversion; waypoints given as x/y don't need it.
+        # Skip creating/waiting on the service entirely when no waypoint requires it.
         from_ll_client = self.create_client(FromLL, "fromLL")
-        self.get_logger().info("Waiting for fromLL service...")
-        from_ll_client.wait_for_service()
-        self.get_logger().info("fromLL service available, loading waypoints")
+        if any("latitude" in w for w in data["waypoints"]):
+            self.get_logger().info("Waiting for fromLL service...")
+            if not from_ll_client.wait_for_service(timeout_sec=10.0):
+                self.get_logger().fatal("fromLL service not available after 10s; cannot convert lat/lon waypoints")
+                raise SystemExit(1)
+            self.get_logger().info("fromLL service available, loading waypoints")
 
         waypoints = []
         for w in data["waypoints"]:
             if "latitude" in w:
+                assert from_ll_client is not None
                 request = FromLL.Request(ll_point=GeoPoint(latitude=w["latitude"], longitude=w["longitude"]))
                 future = from_ll_client.call_async(request)
                 rclpy.spin_until_future_complete(self, future)

--- a/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
+++ b/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
@@ -90,7 +90,6 @@ class AutonavMissionControl(Node):
         waypoints = []
         for w in data["waypoints"]:
             if "latitude" in w:
-                assert from_ll_client is not None
                 request = FromLL.Request(ll_point=GeoPoint(latitude=w["latitude"], longitude=w["longitude"]))
                 future = from_ll_client.call_async(request)
                 rclpy.spin_until_future_complete(self, future)

--- a/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control_config.py
+++ b/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control_config.py
@@ -14,6 +14,8 @@ class AutonavMissionControlConfig:
             detection is re-enabled. Allows the robot to see lane markings as it approaches the zone exit.
         mission_complete_delay_s: Time (s) after the final waypoint is reached before mission_complete is set. Normal
             goal selection continues during this window.
+        from_ll_service_timeout_s: Time (s) to wait for the fromLL service before giving up on lat/lon waypoint
+            conversion.
         map_frame_id: TF frame ID for the map coordinate frame. Global odometry must publish in this frame.
     """
 
@@ -22,6 +24,7 @@ class AutonavMissionControlConfig:
     ramp_approach_radius_m: float = 12.0
     lane_detection_enable_near_exit_radius_m: float = 3.0
     mission_complete_delay_s: float = 10.0
+    from_ll_service_timeout_s: float = 10.0
     map_frame_id: str = "map"
 
     def __post_init__(self) -> None:
@@ -33,3 +36,5 @@ class AutonavMissionControlConfig:
             raise ValueError("AutonavMissionControlConfig: lane_detection_enable_near_exit_radius_m must be >= 0")
         if self.mission_complete_delay_s < 0:
             raise ValueError("AutonavMissionControlConfig: mission_complete_delay_s must be >= 0")
+        if self.from_ll_service_timeout_s <= 0:
+            raise ValueError("AutonavMissionControlConfig: from_ll_service_timeout_s must be > 0")


### PR DESCRIPTION
## What has changed
As title. This has two benefits
1. If we don't need it and don't have the service available we can still run which makes running the code more forgiving
2. We crash if no service is available and is required which makes the failure obvious

## Testing plan
Tested with sim