### PR TITLE
Use extras_require instead of to be deprecated tests_require for setup.py

### DIFF
--- a/src/bringup/setup.py
+++ b/src/bringup/setup.py
@@ -23,7 +23,7 @@ setup(
     maintainer_email="hardyem@umich.edu",
     description="Launch files and shared configuration for the navigation stack",
     license="Apache-2.0",
-    extras_require={},
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [],
     },

--- a/src/core/utils/setup.py
+++ b/src/core/utils/setup.py
@@ -16,5 +16,5 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Utility helpers for nav stack",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
 )

--- a/src/description/common_description/setup.py
+++ b/src/description/common_description/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Common xacro macros for sensors, wheels, and physics",
     license="Apache-2.0",
-    extras_require={},
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [],
     },

--- a/src/description/maverick_description/setup.py
+++ b/src/description/maverick_description/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="URDF description for Maverick",
     license="Apache-2.0",
-    extras_require={},
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [],
     },

--- a/src/hardware/estop_driver/setup.py
+++ b/src/hardware/estop_driver/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ericbi@umich.edu",
     description="Serial e-stop monitor driver",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "estop_driver = estop_driver.estop_driver:main",

--- a/src/hardware/led_driver/setup.py
+++ b/src/hardware/led_driver/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ericbi@umich.edu",
     description="LED indicator driver node",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "led_driver = led_driver.led_driver:main",

--- a/src/hardware/odrive_driver/setup.py
+++ b/src/hardware/odrive_driver/setup.py
@@ -20,7 +20,7 @@ setup(
     maintainer_email="ericb@umich.edu",
     description="Dual ODrive motor controller driver",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "odrive_driver = odrive_driver.odrive_driver:main",

--- a/src/hardware/ublox_driver/setup.py
+++ b/src/hardware/ublox_driver/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="U-Blox ZED-F9P GPS data publisher",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": ["ublox_driver = ublox_driver.ublox_driver:main"],
     },

--- a/src/localization/enc_odom_publisher/setup.py
+++ b/src/localization/enc_odom_publisher/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Encoder odometry publisher node",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "enc_odom_publisher = enc_odom_publisher.enc_odom_publisher:main",

--- a/src/localization/gps_origin_calculator/setup.py
+++ b/src/localization/gps_origin_calculator/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="GPS origin calculator node",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "gps_origin_calculator = gps_origin_calculator.gps_origin_calculator:main",

--- a/src/localization/lat_lon_converter/setup.py
+++ b/src/localization/lat_lon_converter/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Converts GPS latitude/longitude to map-frame points via the fromLL service",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "lat_lon_converter = lat_lon_converter.lat_lon_converter:main",

--- a/src/navigation/autonav_goal_selection/setup.py
+++ b/src/navigation/autonav_goal_selection/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ctrievel@umich.edu",
     description="Local goal selection node for autonav",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "autonav_goal_selection = autonav_goal_selection.autonav_goal_selection:main",

--- a/src/navigation/autonav_mission_control/setup.py
+++ b/src/navigation/autonav_mission_control/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Mission control node for autonav: waypoint management, zone state, and recovery coordination",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "autonav_mission_control = autonav_mission_control.autonav_mission_control:main",

--- a/src/navigation/occupancy_grid_transform/setup.py
+++ b/src/navigation/occupancy_grid_transform/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Occupancy grid transform and inflation layer",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "occupancy_grid_transform = occupancy_grid_transform.occupancy_grid_transform:main",

--- a/src/navigation/path_planning/setup.py
+++ b/src/navigation/path_planning/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ctrievel@umich.edu",
     description="A* path planning",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "path_planning = path_planning.path_planning:main",

--- a/src/navigation/recovery_behavior/setup.py
+++ b/src/navigation/recovery_behavior/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="hannerd@umich.edu",
     description="Recovery behavior node with ultrasonic obstacle avoidance",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "recovery_behavior = recovery_behavior.recovery_executable:main",

--- a/src/simulation/occupancy_grid_simulator/setup.py
+++ b/src/simulation/occupancy_grid_simulator/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Simulates an occupancy grid from a static obstacle map for use in simulation",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "occupancy_grid_simulator = occupancy_grid_simulator.occupancy_grid_simulator:main",

--- a/src/simulation/sensor_simulator/setup.py
+++ b/src/simulation/sensor_simulator/setup.py
@@ -16,7 +16,7 @@ setup(
     maintainer_email="ryanliao@umich.edu",
     description="Simulates enc_vel, imu, and gps sensor topics with Gaussian noise and drift",
     license="Apache-2.0",
-    tests_require=["pytest"],
+    extras_require={"test": ["pytest"]},
     entry_points={
         "console_scripts": [
             "sensor_simulator = sensor_simulator.sensor_simulator:main",


### PR DESCRIPTION
## What has changed
As title. tests_require is getting deprecated in setuptools 77 which is why we get a ton of deprecation warnings. This becomes an actual issue in jazzy / ubuntu 24.04 since it ships a newer version of setuptools, and if tests_require is missing it would fall back to unittest which errors on no test, breaking `colcon test`

We replace tests_require with `extras_require={"test": ["pytest"]}` to fix this problem. This will no longer be a problem for jazzy / lyrical since the default of ros2 pkg create is `extras_require`

## Testing plan
Tested on jazzy / lyrical and no error