### PR TITLE
Use statically typed required params directly for config loader

### DIFF
--- a/src/core/utils/test/test_config.py
+++ b/src/core/utils/test/test_config.py
@@ -13,6 +13,13 @@ class Param:
 
 
 class MockNode:
+    """Minimal mock for rclpy.Node, mimicking its parameter behavior.
+
+    declare_parameter accepts either a default value or a Parameter.Type. A value is stored as default while a type
+        leaves the parameter as required with the given static type
+    get_parameter raises ParameterUninitializedException when a parameter is required and not set.
+    """
+
     def __init__(self, initial: dict[str, object] | None = None):
         self._store: dict[str, object] = dict(initial or {})
         self.declared: list[tuple[str, object | None]] = []

--- a/src/core/utils/test/test_config.py
+++ b/src/core/utils/test/test_config.py
@@ -2,7 +2,8 @@ from dataclasses import dataclass, field
 from pathlib import Path
 
 import pytest
-from rcl_interfaces.msg import ParameterDescriptor
+from rclpy.exceptions import ParameterUninitializedException
+from rclpy.parameter import Parameter
 from utils.config import load
 
 
@@ -19,13 +20,15 @@ class MockNode:
     def get_name(self) -> str:
         return "MockNode"
 
-    def declare_parameter(self, key: str, default_value=None, descriptor: ParameterDescriptor | None = None):
-        self.declared.append((key, default_value))
-        if key not in self._store:
-            self._store[key] = default_value
+    def declare_parameter(self, key: str, value=None):
+        self.declared.append((key, value))
+        if key not in self._store and not isinstance(value, Parameter.Type):
+            self._store[key] = value
 
     def get_parameter(self, key: str) -> Param:
-        return Param(self._store.get(key, None))
+        if key not in self._store:
+            raise ParameterUninitializedException(key)
+        return Param(self._store[key])
 
 
 def test_load_required_param_success():
@@ -36,7 +39,7 @@ def test_load_required_param_success():
     node = MockNode(initial={"rate": 10})
     config = load(node, Config)
 
-    assert ("rate", None) in node.declared
+    assert ("rate", Parameter.Type.INTEGER) in node.declared
     assert config.rate == 10
 
 
@@ -46,7 +49,7 @@ def test_load_required_param_missing_raises():
         rate: int
 
     node = MockNode(initial={})
-    with pytest.raises(RuntimeError, match=r"Required parameter 'rate' not set"):
+    with pytest.raises(ParameterUninitializedException):
         load(node, Config)
 
 
@@ -171,7 +174,7 @@ def test_load_nested_without_default_instance_keeps_leaf_required():
         inner: InnerWithRequired
 
     node = MockNode(initial={})
-    with pytest.raises(RuntimeError, match=r"Required parameter 'inner.gain' not set"):
+    with pytest.raises(ParameterUninitializedException):
         load(node, Config)
 
 

--- a/src/core/utils/utils/config.py
+++ b/src/core/utils/utils/config.py
@@ -69,7 +69,6 @@ from dataclasses import MISSING, Field, dataclass, fields, is_dataclass
 from pathlib import Path
 from typing import Any, Generic, Literal, TypeVar, cast, get_args, get_origin, get_type_hints
 
-from rcl_interfaces.msg import ParameterDescriptor
 from rclpy.node import Node
 from rclpy.parameter import Parameter
 
@@ -143,7 +142,7 @@ def load(node: Node, cls: type[T]) -> T:
     Returns:
         An instance of `cls` populated from ROS 2 parameters.
     Raises:
-        RuntimeError: If a required parameter (field without a default) is missing or unset.
+        ParameterUninitializedException: If a required parameter (field without a default) is missing or unset.
     """
     return _load(node, cls, prefix="", defaults=None)
 
@@ -177,13 +176,10 @@ def _load(node: Node, cls: type[T], prefix: str, defaults: Any) -> T:
             raise TypeError(f"Parameter '{key}' has unsupported type {field_type!r}. Supported types: {supported}")
 
         if default_value is MISSING:
-            node.declare_parameter(key, descriptor=ParameterDescriptor(type=entry.ros_type.value))
+            node.declare_parameter(key, entry.ros_type)
         else:
             node.declare_parameter(key, entry.serialize(default_value))
 
-        value = node.get_parameter(key).value
-        if value is None:
-            raise RuntimeError(f"Required parameter '{key}' not set for node '{node.get_name()}'")
-        kwargs[f.name] = entry.deserialize(value)
+        kwargs[f.name] = entry.deserialize(node.get_parameter(key).value)
 
     return cls(**kwargs)


### PR DESCRIPTION
## What has changed
For required parameters, instead of passing a parameter descriptor with the type, we can just pass the type as the default value. rclpy will view the parameter as a statically typed required parameter and raise on missing which is more correct for us. 

The original code breaks on Jazzy due to a bug that forbids declaring statically typed required parameters using parameter descriptors. This fixes it. 

## Testing plan
Unit test passes. Simulation runs