### PR TITLE
Remove ament_lint from repo

### DIFF
--- a/scripts/create_package.py
+++ b/scripts/create_package.py
@@ -3,10 +3,37 @@ import argparse
 import re
 import shutil
 import sys
+from pathlib import Path
 
 from common import ROOT, die, run
 
 BUILD_TYPES = {"python": "ament_python", "cpp": "ament_cmake"}
+
+# ros2 pkg create bakes these linters into the template package.xml, but we lint with ruff + mypy + clang-format
+# (see pyproject.toml) and ship no ament lint stubs, so strip them from every new package. The ament_python template
+# emits the first three; the ament_cmake template emits the last two (plus a CMake block, see strip_lint_cmake_block).
+LINT_TEST_DEPENDS = ("ament_copyright", "ament_flake8", "ament_pep257", "ament_lint_auto", "ament_lint_common")
+
+
+def strip_lint_test_depends(package_xml: Path) -> None:
+    lines = package_xml.read_text().splitlines(keepends=True)
+    kept = [line for line in lines if not any(f"<test_depend>{dep}</test_depend>" in line for dep in LINT_TEST_DEPENDS)]
+    package_xml.write_text(re.sub(r"\n{3,}", "\n\n", "".join(kept)))
+
+
+def strip_lint_cmake_block(cmakelists: Path) -> None:
+    # ament_cmake's template adds an `if(BUILD_TESTING) ... endif()` block that runs ament_lint_auto; drop it
+    # so the package builds without the linter deps we just removed from package.xml.
+    out: list[str] = []
+    skipping = False
+    for line in cmakelists.read_text().splitlines():
+        if line.strip() == "if(BUILD_TESTING)":
+            skipping = True
+        elif skipping:
+            skipping = line.strip() != "endif()"
+        else:
+            out.append(line)
+    cmakelists.write_text(re.sub(r"\n{3,}", "\n\n", "\n".join(out) + "\n"))
 
 
 def main() -> None:
@@ -41,6 +68,9 @@ def main() -> None:
     pkg_dir = dest / pkg_name
     (pkg_dir / "LICENSE").unlink(missing_ok=True)
     shutil.rmtree(pkg_dir / "test", ignore_errors=True)
+    strip_lint_test_depends(pkg_dir / "package.xml")
+    if args.type == "cpp":
+        strip_lint_cmake_block(pkg_dir / "CMakeLists.txt")
 
     print(f"==> Package '{pkg_name}' created successfully at {args.dir}/{pkg_name}")
 

--- a/src/bringup/package.xml
+++ b/src/bringup/package.xml
@@ -28,9 +28,6 @@
   <exec_depend>occupancy_grid_visualization</exec_depend>
   <exec_depend>python3-typing-extensions</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/hardware/estop_driver/package.xml
+++ b/src/hardware/estop_driver/package.xml
@@ -10,9 +10,6 @@
   <exec_depend>python3-serial</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/hardware/led_driver/package.xml
+++ b/src/hardware/led_driver/package.xml
@@ -13,9 +13,6 @@
   <exec_depend>python3-serial</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/hardware/odrive_driver/package.xml
+++ b/src/hardware/odrive_driver/package.xml
@@ -15,9 +15,6 @@
   <exec_depend>python3-playsound-pip</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/hardware/ublox_driver/package.xml
+++ b/src/hardware/ublox_driver/package.xml
@@ -14,9 +14,6 @@
 	<exec_depend>python3-serial</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/localization/enc_odom_publisher/package.xml
+++ b/src/localization/enc_odom_publisher/package.xml
@@ -14,9 +14,6 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>nav_msgs</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/localization/gps_origin_calculator/package.xml
+++ b/src/localization/gps_origin_calculator/package.xml
@@ -11,9 +11,6 @@
   <exec_depend>sensor_msgs</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/localization/lat_lon_converter/package.xml
+++ b/src/localization/lat_lon_converter/package.xml
@@ -13,9 +13,6 @@
   <exec_depend>utils</exec_depend>
   <exec_depend>python3-pyproj</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/navigation/autonav_goal_selection/package.xml
+++ b/src/navigation/autonav_goal_selection/package.xml
@@ -19,9 +19,6 @@
   <exec_depend>visualization_msgs</exec_depend>
   <exec_depend>builtin_interfaces</exec_depend>
   
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/navigation/autonav_mission_control/package.xml
+++ b/src/navigation/autonav_mission_control/package.xml
@@ -17,9 +17,6 @@
   <exec_depend>robot_localization</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/navigation/occupancy_grid_transform/package.xml
+++ b/src/navigation/occupancy_grid_transform/package.xml
@@ -18,9 +18,6 @@
   <exec_depend>tf2_ros_py</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/navigation/path_planning/package.xml
+++ b/src/navigation/path_planning/package.xml
@@ -15,9 +15,6 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>tf2_geometry_msgs</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/navigation/path_smoothing/package.xml
+++ b/src/navigation/path_smoothing/package.xml
@@ -13,9 +13,6 @@
   <exec_depend>std_msgs</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/navigation/recovery_behavior/package.xml
+++ b/src/navigation/recovery_behavior/package.xml
@@ -14,9 +14,6 @@
   <exec_depend>python3-serial</exec_depend>
   <exec_depend>utils</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/simulation/occupancy_grid_simulator/package.xml
+++ b/src/simulation/occupancy_grid_simulator/package.xml
@@ -13,9 +13,6 @@
   <exec_depend>utils</exec_depend>
   <exec_depend>python3-numpy</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/simulation/sensor_simulator/package.xml
+++ b/src/simulation/sensor_simulator/package.xml
@@ -16,9 +16,6 @@
   <exec_depend>tf2_ros</exec_depend>
   <exec_depend>python3-pyproj</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>

--- a/src/visualization/occupancy_grid_visualization/package.xml
+++ b/src/visualization/occupancy_grid_visualization/package.xml
@@ -13,9 +13,6 @@
   <exec_depend>python3-numpy</exec_depend>
   <exec_depend>rclpy</exec_depend>
 
-  <test_depend>ament_copyright</test_depend>
-  <test_depend>ament_flake8</test_depend>
-  <test_depend>ament_pep257</test_depend>
   <test_depend>python3-pytest</test_depend>
 
   <export>


### PR DESCRIPTION
## What has changed
1. Remove unused test_depends from package.xml (e.g. ament_copyright, ament_flake8). We use ruff + mypy for linting
2. Modify package creation script to strip them as creation time

## Testing plan
Created stub python / cpp packages and made sure they are minimal
CI passes