### PR TITLE
Add context manager for running nodes

### DIFF
--- a/src/core/utils/README.md
+++ b/src/core/utils/README.md
@@ -86,6 +86,24 @@ self.create_subscription(MissionState, "mission_state", self.callback, utils.qos
 
 In RViz, set the topic's **Durability Policy** to `Transient Local` to receive latched messages.
 
+## utils.lifecycle
+Runs a node's init / spin / shutdown lifecycle so each node's `main` is a single line. All the rclpy / node lifetime is
+automatically managed and all shutdown exceptions are handled internally.
+```py
+utils.lifecycle.run_node(Planner)
+
+# For nodes with arguments, wrap it in a lambda
+utils.lifecycle.run_node(lambda: ImuMonitor(args.topic))
+
+# For nodes with non-default executors
+utils.lifecycle.run_node(Planner, executor=MultiThreadedExecutor())
+```
+
+### Stopping or failing from inside a node
+- `raise SystemExit(0)` to stop a one-shot node after it finishes its job (clean exit 0).
+- `raise SystemExit(1)` for a fatal condition (e.g. a device that won't connect).
+- Any other exception for an unexpected error (propagates with a traceback).
+
 ## utils.math
 Math utilities.
 

--- a/src/core/utils/utils/lifecycle.py
+++ b/src/core/utils/utils/lifecycle.py
@@ -1,0 +1,44 @@
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
+from typing import TypeVar
+
+import rclpy
+from rclpy.executors import Executor, ExternalShutdownException
+from rclpy.node import Node
+
+NodeT = TypeVar("NodeT", bound=Node)
+
+
+@contextmanager
+def ros() -> Iterator[None]:
+    """Manage the rclpy context lifetime: init on enter, try_shutdown on exit.
+
+    TODO: Remove in Lyrical as rclpy.init() ships with a context manager directly
+    """
+    rclpy.init()
+    try:
+        yield
+    finally:
+        rclpy.try_shutdown()
+
+
+@contextmanager
+def managed_node(factory: Callable[[], NodeT]) -> Iterator[NodeT]:
+    """Manage the node lifetime: construct on enter, destroy_node on exit."""
+    node = factory()
+    try:
+        yield node
+    finally:
+        node.destroy_node()
+
+
+def run_node(factory: Callable[[], NodeT], *, executor: Executor | None = None) -> None:
+    """Spin a node until shutdown. Use as the whole body of a package's console_scripts `main`.
+
+    Pass `executor` to spin on something other than the default global single-threaded executor.
+    """
+    try:
+        with ros(), managed_node(factory) as node:
+            rclpy.spin(node, executor)
+    except (KeyboardInterrupt, ExternalShutdownException):
+        pass

--- a/src/hardware/estop_driver/estop_driver/estop_driver.py
+++ b/src/hardware/estop_driver/estop_driver/estop_driver.py
@@ -1,8 +1,8 @@
 import os
 
-import rclpy
 import serial
 import utils.config
+import utils.lifecycle
 from rclpy.node import Node
 
 from .estop_driver_config import EstopDriverConfig
@@ -23,8 +23,6 @@ class EstopDriver(Node):
             self.get_logger().info(f"Connected to {self.config.serial_port}")
         except serial.SerialException as e:
             self.get_logger().error(f"Failed to connect to {self.config.serial_port}: {e}")
-            # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
-            # https://github.com/ros2/rclpy/issues/1646
             raise SystemExit(1) from None
 
         self.create_timer(self.config.poll_period_s, self.poll)
@@ -69,10 +67,4 @@ class EstopDriver(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = EstopDriver()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(EstopDriver)

--- a/src/hardware/led_driver/led_driver/led_driver.py
+++ b/src/hardware/led_driver/led_driver/led_driver.py
@@ -1,8 +1,8 @@
 import time
 
-import rclpy
 import serial
 import utils.config
+import utils.lifecycle
 import utils.qos
 from geometry_msgs.msg import Twist
 from maverick_msgs.msg import MissionState
@@ -43,8 +43,6 @@ class LedDriver(Node):
             self.wait_for_ready()
         except (serial.SerialException, RuntimeError) as e:
             self.get_logger().error(f"Failed to connect to {self.config.serial_port}: {e}")
-            # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
-            # https://github.com/ros2/rclpy/issues/1646
             raise SystemExit(1) from None
 
         self.create_timer(self.config.update_period_s, self.update)
@@ -129,10 +127,4 @@ class LedDriver(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = LedDriver()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(LedDriver)

--- a/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
+++ b/src/hardware/odrive_driver/odrive_driver/odrive_driver.py
@@ -2,8 +2,8 @@ from pathlib import Path
 
 import odrive
 import odrive.utils
-import rclpy
 import utils.config
+import utils.lifecycle
 from ament_index_python.packages import get_package_share_directory
 from geometry_msgs.msg import Twist, TwistWithCovariance, TwistWithCovarianceStamped, Vector3
 from odrive.enums import AxisState, ControlMode, InputMode, ODriveError
@@ -34,7 +34,9 @@ class OdriveDriver(Node):
             self.debug_publisher = self.create_publisher(Float32MultiArray, "~/debug", 10)
             self.create_timer(self.config.publish_period_s, self.publish_debug_info)
 
-    def init(self) -> bool:
+        self.connect()
+
+    def connect(self) -> None:
         try:
             self.get_logger().info(f"Finding left ODrive (serial number {self.config.left_odrive.serial})...")
             self.odrive_left = odrive.find_any(serial_number=self.config.left_odrive.serial)
@@ -45,10 +47,9 @@ class OdriveDriver(Node):
             self.odrive_right = odrive.find_any(serial_number=self.config.right_odrive.serial)
             self.initialize_odrive(self.odrive_right)
             self.get_logger().info("Found right ODrive")
-            return True
         except Exception as e:
             self.get_logger().fatal(f"Failed to initialize ODrive: {e}")
-            return False
+            raise SystemExit(1) from None
 
     def cmd_vel_callback(self, msg: Twist) -> None:
         self.watchdog_timer.reset()
@@ -139,14 +140,4 @@ class OdriveDriver(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = OdriveDriver()
-
-    if not node.init():
-        return
-
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(OdriveDriver)

--- a/src/hardware/odrive_driver/scripts/plot_motor_signals.py
+++ b/src/hardware/odrive_driver/scripts/plot_motor_signals.py
@@ -2,7 +2,7 @@ import argparse
 from collections import deque
 
 import matplotlib.pyplot as plt
-import rclpy
+import utils.lifecycle
 from rclpy.node import Node
 from std_msgs.msg import Float32MultiArray
 
@@ -57,8 +57,6 @@ class MotorSignalPlotter(Node):
     def render(self) -> None:
         # Once the window is closed its canvas is freed, drawing on it would be a use after free in the GUI backend
         if not plt.fignum_exists(self.fig.number):
-            # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
-            # https://github.com/ros2/rclpy/issues/1646
             raise SystemExit(0)
 
         xs = range(len(self.data["l_iq_sp"]))
@@ -83,14 +81,7 @@ def main() -> None:
     )
     args = parser.parse_args()
 
-    rclpy.init()
-    node = MotorSignalPlotter(window=args.window, frame_rate=args.frame_rate)
-
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(lambda: MotorSignalPlotter(window=args.window, frame_rate=args.frame_rate))
 
 
 if __name__ == "__main__":

--- a/src/hardware/ublox_driver/ublox_driver/ublox_driver.py
+++ b/src/hardware/ublox_driver/ublox_driver/ublox_driver.py
@@ -1,8 +1,8 @@
 from datetime import datetime, timezone
 
-import rclpy
 import serial
 import utils.config
+import utils.lifecycle
 from builtin_interfaces.msg import Time
 from pyubx2 import UBX_PROTOCOL, UBXMessage, UBXReader
 from rclpy.node import Node
@@ -32,8 +32,6 @@ class UbloxDriver(Node):
             self.get_logger().info(f"Connected to {self.config.serial_port}")
         except serial.SerialException as e:
             self.get_logger().error(f"Failed to connect to {self.config.serial_port}: {e}")
-            # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
-            # https://github.com/ros2/rclpy/issues/1646
             raise SystemExit(1) from None
 
         self.ubx_reader = UBXReader(self.serial, protfilter=UBX_PROTOCOL)
@@ -115,10 +113,4 @@ class UbloxDriver(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = UbloxDriver()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(UbloxDriver)

--- a/src/hardware/vectornav_driver/scripts/euler_monitor.py
+++ b/src/hardware/vectornav_driver/scripts/euler_monitor.py
@@ -1,7 +1,7 @@
 import argparse
 import math
 
-import rclpy
+import utils.lifecycle
 from rclpy.node import Node
 from sensor_msgs.msg import Imu
 
@@ -46,14 +46,7 @@ def main():
     parser.add_argument("topic", nargs="?", default="vectornav/imu", help="IMU topic name")
     args = parser.parse_args()
 
-    rclpy.init()
-    node = ImuEulerNode(args.topic)
-
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(lambda: ImuEulerNode(args.topic))
 
 
 if __name__ == "__main__":

--- a/src/hardware/vectornav_driver/scripts/vectornav_monitor.py
+++ b/src/hardware/vectornav_driver/scripts/vectornav_monitor.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum, IntEnum
 
-import rclpy
+import utils.lifecycle
 from rclpy.node import Node
 from rclpy.time import Time
 from std_msgs.msg import Float32, Float32MultiArray, UInt16
@@ -479,14 +479,7 @@ class VectornavMonitor(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = VectornavMonitor()
-
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(VectornavMonitor)
 
 
 if __name__ == "__main__":

--- a/src/localization/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher.py
+++ b/src/localization/enc_odom_publisher/enc_odom_publisher/enc_odom_publisher.py
@@ -1,5 +1,5 @@
-import rclpy
 import utils.config
+import utils.lifecycle
 from geometry_msgs.msg import (
     Pose,
     PoseWithCovariance,
@@ -106,10 +106,4 @@ class EncOdomPublisher(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = EncOdomPublisher()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(EncOdomPublisher)

--- a/src/localization/gps_origin_calculator/gps_origin_calculator/gps_origin_calculator.py
+++ b/src/localization/gps_origin_calculator/gps_origin_calculator/gps_origin_calculator.py
@@ -2,8 +2,8 @@ import json
 import math
 from statistics import median
 
-import rclpy
 import utils.config
+import utils.lifecycle
 from rclpy.node import Node
 from sensor_msgs.msg import NavSatFix
 
@@ -73,8 +73,6 @@ class GpsOriginCalculator(Node):
         self.done = True
         self.compute_and_print_origin()
 
-        # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
-        # https://github.com/ros2/rclpy/issues/1646
         raise SystemExit(0)
 
     def compute_and_print_origin(self) -> None:
@@ -115,10 +113,4 @@ class GpsOriginCalculator(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = GpsOriginCalculator()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(GpsOriginCalculator)

--- a/src/localization/lat_lon_converter/lat_lon_converter/lat_lon_converter.py
+++ b/src/localization/lat_lon_converter/lat_lon_converter/lat_lon_converter.py
@@ -1,5 +1,5 @@
-import rclpy
 import utils.config
+import utils.lifecycle
 from geometry_msgs.msg import Point
 from pyproj import Transformer
 from rclpy.node import Node
@@ -29,10 +29,4 @@ class LatLonConverter(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = LatLonConverter()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(LatLonConverter)

--- a/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
+++ b/src/navigation/autonav_goal_selection/autonav_goal_selection/autonav_goal_selection.py
@@ -1,7 +1,7 @@
-import rclpy
 import tf2_geometry_msgs  # noqa: F401 — registers PointStamped transform
 import tf2_ros
 import utils.config
+import utils.lifecycle
 import utils.qos
 from geometry_msgs.msg import PointStamped, Vector3
 from maverick_msgs.msg import MissionState
@@ -155,10 +155,4 @@ class AutonavGoalSelection(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = AutonavGoalSelection()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(AutonavGoalSelection)

--- a/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
+++ b/src/navigation/autonav_mission_control/autonav_mission_control/autonav_mission_control.py
@@ -5,6 +5,7 @@ from typing import Any, NamedTuple
 
 import rclpy
 import utils.config
+import utils.lifecycle
 import utils.qos
 from geographic_msgs.msg import GeoPoint
 from geometry_msgs.msg import PointStamped
@@ -231,8 +232,6 @@ class AutonavMissionControl(Node):
             self.publish_state()
 
             # Exiting signals mission completion to the launch, which shuts down autonav
-            # TODO: We don't call rclpy.shutdown() here because it causes a deadlock in humble
-            # https://github.com/ros2/rclpy/issues/1646
             self.get_logger().info("Shutting down")
             raise SystemExit(0)
 
@@ -297,10 +296,4 @@ class AutonavMissionControl(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = AutonavMissionControl()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(AutonavMissionControl)

--- a/src/navigation/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform.py
+++ b/src/navigation/occupancy_grid_transform/occupancy_grid_transform/occupancy_grid_transform.py
@@ -1,7 +1,7 @@
 import numpy as np
-import rclpy
 import tf2_geometry_msgs  # noqa: F401 - registers PoseStamped transform handlers
 import utils.config
+import utils.lifecycle
 import utils.qos
 from geometry_msgs.msg import PoseStamped
 from maverick_msgs.msg import MissionState
@@ -79,10 +79,4 @@ class OccupancyGridTransform(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = OccupancyGridTransform()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(OccupancyGridTransform)

--- a/src/navigation/path_planning/path_planning/path_planning.py
+++ b/src/navigation/path_planning/path_planning/path_planning.py
@@ -1,6 +1,7 @@
 import rclpy
 import tf2_geometry_msgs  # noqa: F401 - registers PointStamped transform support
 import utils.config
+import utils.lifecycle
 from geometry_msgs.msg import PointStamped, Pose, PoseStamped, Quaternion
 from nav_msgs.msg import OccupancyGrid, Odometry, Path
 from rclpy.node import Node
@@ -101,10 +102,4 @@ class PathPlanner(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = PathPlanner()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(PathPlanner)

--- a/src/navigation/path_smoothing/path_smoothing/path_smoothing.py
+++ b/src/navigation/path_smoothing/path_smoothing/path_smoothing.py
@@ -1,5 +1,5 @@
-import rclpy
 import utils.config
+import utils.lifecycle
 from geometry_msgs.msg import Pose, PoseStamped, Quaternion
 from nav_msgs.msg import Path
 from rclpy.node import Node
@@ -57,10 +57,4 @@ class PathSmoother(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = PathSmoother()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(PathSmoother)

--- a/src/navigation/path_tracking/path_tracking/path_tracking.py
+++ b/src/navigation/path_tracking/path_tracking/path_tracking.py
@@ -1,7 +1,7 @@
 import math
 
-import rclpy
 import utils.config
+import utils.lifecycle
 import utils.qos
 from geometry_msgs.msg import Twist
 from maverick_msgs.msg import MissionState
@@ -94,10 +94,4 @@ class PathTracking(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = PathTracking()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(PathTracking)

--- a/src/navigation/recovery_behavior/recovery_behavior/recovery_executable.py
+++ b/src/navigation/recovery_behavior/recovery_behavior/recovery_executable.py
@@ -1,15 +1,13 @@
 from statistics import median
 
-import rclpy
 import serial
+import utils.lifecycle
 import utils.qos
 from geometry_msgs.msg import Twist
 from maverick_msgs.msg import MissionState
-from rclpy.executors import ExternalShutdownException
 from rclpy.node import Node
 from std_srvs.srv import Trigger
 
-recovery_executable = None
 THRESHOLD_DISTANCE = 60  # centimeters, distance needed to start backing up
 BACKUP_ALLOWANCE = (
     30  # centimeters, if the ultrasound reader reads less than this, the robot stops backing up and ends recovery
@@ -213,16 +211,5 @@ class RecoveryExecutable(Node):
 
 
 # this actually runs the code
-def main(args=None):
-    try:
-        rclpy.init(args=args)
-        global recovery_executable
-        recovery_executable = RecoveryExecutable()
-
-        rclpy.spin(recovery_executable)
-    except (KeyboardInterrupt, ExternalShutdownException):
-        pass
-
-
-if __name__ == "__main__":
-    main()
+def main() -> None:
+    utils.lifecycle.run_node(RecoveryExecutable)

--- a/src/simulation/occupancy_grid_simulator/occupancy_grid_simulator/occupancy_grid_simulator.py
+++ b/src/simulation/occupancy_grid_simulator/occupancy_grid_simulator/occupancy_grid_simulator.py
@@ -4,8 +4,8 @@ import json
 import math
 
 import numpy as np
-import rclpy
 import utils.config
+import utils.lifecycle
 import utils.qos
 from nav_msgs.msg import MapMetaData, OccupancyGrid, Odometry
 from rclpy.node import Node
@@ -222,10 +222,4 @@ class OccupancyGridSimulator(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = OccupancyGridSimulator()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(OccupancyGridSimulator)

--- a/src/simulation/sensor_simulator/sensor_simulator/sensor_simulator.py
+++ b/src/simulation/sensor_simulator/sensor_simulator/sensor_simulator.py
@@ -1,8 +1,8 @@
 import math
 import random
 
-import rclpy
 import utils.config
+import utils.lifecycle
 from geometry_msgs.msg import (
     Pose,
     PoseWithCovariance,
@@ -338,10 +338,4 @@ class SensorSimulator(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = SensorSimulator()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(SensorSimulator)

--- a/src/visualization/occupancy_grid_visualization/occupancy_grid_visualization/occupancy_grid_visualizer.py
+++ b/src/visualization/occupancy_grid_visualization/occupancy_grid_visualization/occupancy_grid_visualizer.py
@@ -1,5 +1,5 @@
 import numpy as np
-import rclpy
+import utils.lifecycle
 from foxglove_msgs.msg import PackedElementField, VoxelGrid
 from geometry_msgs.msg import Vector3
 from nav_msgs.msg import OccupancyGrid
@@ -36,10 +36,4 @@ class FoxgloveOccupancyGrid(Node):
 
 
 def main() -> None:
-    rclpy.init()
-    node = FoxgloveOccupancyGrid()
-    try:
-        rclpy.spin(node)
-    finally:
-        node.destroy_node()
-        rclpy.shutdown()
+    utils.lifecycle.run_node(FoxgloveOccupancyGrid)


### PR DESCRIPTION
## What has changed
1. Add context managers (Python's version of RAII) for running rclpy context / nodes so that it is automatically cleaned up.
2. Add a function to automatically run nodes to simplify each node's main

## Testing plan
Ran simulation locally