### PR TITLE
Remove geometry_msgs.Point access of WorldOccupancyGrid

### DIFF
--- a/src/core/utils/README.md
+++ b/src/core/utils/README.md
@@ -177,9 +177,6 @@ locations - without directly interacting with grid indices. Conceptually, the oc
 world representation: world points are projected into grid cells on demand, and any point outside the underlying grid
 bounds is treated as unknown.
 
-All public methods accept either `geometry_msgs/Point` or `Point2d`. Methods that return points (`neighbors4`,
-`neighbors8`, `neighbors_forward`, `in_bound_points`) preserve the caller's point type.
-
 ### Conventions / Transformations
 The supplied occupancy grid is assumed to have the following conventions (matching ROS conventions):
 - +x points forward from the robot
@@ -199,12 +196,12 @@ outside `[0..width) × [0..height)` return an unknown cell.
 | `is_drivable` | True if occupancy probability is ≤ 30 |
 
 ### Full grid iteration in continuous space via in_bound_points
-To iterate through all in-bound cells, `WorldOccupancyGrid` provides `in_bound_points(point_type)`. Pass `Point` or
-`Point2d` to control the yielded type.
+To iterate through all in-bound cells, `WorldOccupancyGrid` provides `in_bound_points()`, which yields the `Point2d`
+center of every in-bound cell.
 
 Example pattern:
 ```py
-for candidate in grid.in_bound_points(Point2d):
+for candidate in grid.in_bound_points():
     if grid.state(candidate).is_drivable:
         # found drivable cell, do something special
 ```
@@ -218,11 +215,9 @@ Each neighbor expansion:
 2. Expands neighboring cells in grid index space
 3. Converts those neighboring cells back into world points by returning the center of each cell
 
-The returned points are the same type as the input (`Point` or `Point2d`), so no conversion is needed at the call site.
-
 Example pattern:
 ```py
-for candidate in grid.neighbors8(current):  # candidate matches type of current
+for candidate in grid.neighbors8(current):
     if not grid.state(candidate).is_drivable:
         continue
 ```

--- a/src/core/utils/test/test_world_occupancy_grid.py
+++ b/src/core/utils/test/test_world_occupancy_grid.py
@@ -1,13 +1,12 @@
 import math
 
-from geometry_msgs.msg import Point
 from nav_msgs.msg import MapMetaData, OccupancyGrid
 from utils.geometry import Point2d, Pose2d, Rotation2d
 from utils.world_occupancy_grid import WorldOccupancyGrid
 
 
-def point_is_close(a: Point, b: Point, tol: float = 0.001) -> bool:
-    return abs(a.x - b.x) < tol and abs(a.y - b.y) < tol and abs(a.z - b.z) < tol
+def point_is_close(a: Point2d, b: Point2d, tol: float = 0.001) -> bool:
+    return a.distance(b) < tol
 
 
 def make_occupancy_grid() -> OccupancyGrid:
@@ -25,15 +24,15 @@ def make_occupancy_grid() -> OccupancyGrid:
 def test_world_to_grid_index():
     grid = WorldOccupancyGrid(make_occupancy_grid())
 
-    assert grid._world_to_grid_index(Point(x=3.25, y=3.5, z=0.0)) == (4, 3)
-    assert grid._world_to_grid_index(Point(x=2.0, y=1.0, z=0.0)) == (-1, 0)
+    assert grid._world_to_grid_index(Point2d(x=3.25, y=3.5)) == (4, 3)
+    assert grid._world_to_grid_index(Point2d(x=2.0, y=1.0)) == (-1, 0)
 
 
 def test_grid_index_center_to_world():
     grid = WorldOccupancyGrid(make_occupancy_grid())
 
-    assert point_is_close(grid._grid_index_center_to_world(2, 0, Point), Point(x=3.2271, y=1.8425, z=0.0))
-    assert point_is_close(grid._grid_index_center_to_world(2, -1, Point), Point(x=3.4771, y=1.4095, z=0.0))
+    assert point_is_close(grid._grid_index_center_to_world(2, 0), Point2d(x=3.2271, y=1.8425))
+    assert point_is_close(grid._grid_index_center_to_world(2, -1), Point2d(x=3.4771, y=1.4095))
 
 
 def test_state():
@@ -42,15 +41,15 @@ def test_state():
 
     grid = WorldOccupancyGrid(occupancy_grid)
 
-    assert grid.state(Point(x=2.5, y=2.0, z=0.0)).is_drivable
-    assert not grid.state(Point(x=3.25, y=3.5, z=0.0)).is_drivable
-    assert grid.state(Point(x=2.0, y=1.0, z=0.0)).is_unknown
+    assert grid.state(Point2d(x=2.5, y=2.0)).is_drivable
+    assert not grid.state(Point2d(x=3.25, y=3.5)).is_drivable
+    assert grid.state(Point2d(x=2.0, y=1.0)).is_unknown
 
 
 def test_neighbors():
     grid = WorldOccupancyGrid(make_occupancy_grid())
 
-    point = Point(x=3.25, y=3.5, z=0.0)
+    point = Point2d(x=3.25, y=3.5)
     assert grid._world_to_grid_index(point) == (4, 3)
 
     neighbors4 = list(grid.neighbors4(point))
@@ -91,12 +90,12 @@ def test_all_in_bound():
         )
     )
 
-    points = list(grid.in_bound_points(Point))
+    points = list(grid.in_bound_points())
     expected = [
-        Point(x=1.0, y=1.0, z=0.0),
-        Point(x=3.0, y=1.0, z=0.0),
-        Point(x=1.0, y=3.0, z=0.0),
-        Point(x=3.0, y=3.0, z=0.0),
+        Point2d(x=1.0, y=1.0),
+        Point2d(x=3.0, y=1.0),
+        Point2d(x=1.0, y=3.0),
+        Point2d(x=3.0, y=3.0),
     ]
 
     assert len(points) == len(expected)
@@ -107,8 +106,8 @@ def test_all_in_bound():
 def test_hash_key_same_grid():
     grid = WorldOccupancyGrid(make_occupancy_grid())
 
-    point1 = Point(x=3.25, y=3.5, z=0.0)
-    point2 = Point(x=3.25, y=3.5, z=0.0)
+    point1 = Point2d(x=3.25, y=3.5)
+    point2 = Point2d(x=3.25, y=3.5)
     assert grid.hash_key(point1) == grid.hash_key(point2)
 
 
@@ -120,7 +119,7 @@ def test_hash_key_unique_indices():
 
     keys = []
     for ix, iy in indices:
-        world = grid._grid_index_center_to_world(ix, iy, Point)
+        world = grid._grid_index_center_to_world(ix, iy)
         assert grid._world_to_grid_index(world) == (ix, iy)
         keys.append(grid.hash_key(world))
 

--- a/src/core/utils/utils/world_occupancy_grid.py
+++ b/src/core/utils/utils/world_occupancy_grid.py
@@ -3,14 +3,11 @@ from __future__ import annotations
 import math
 from collections.abc import Iterator
 from dataclasses import dataclass
-from typing import ClassVar, TypeVar
+from typing import ClassVar
 
-from geometry_msgs.msg import Point
 from nav_msgs.msg import OccupancyGrid
 
 from utils.geometry import Point2d, Pose2d
-
-PointT = TypeVar("PointT", Point, Point2d)
 
 
 @dataclass(frozen=True)
@@ -82,7 +79,7 @@ class WorldOccupancyGrid:
         self._occupancy_grid = grid
         self._origin = Pose2d.from_ros(self._occupancy_grid.info.origin)
 
-    def state(self, point: Point | Point2d) -> CellState:
+    def state(self, point: Point2d) -> CellState:
         """
         Query the occupancy state at a world-coordinate point.
 
@@ -102,21 +99,18 @@ class WorldOccupancyGrid:
 
         return CellState(self._occupancy_grid.data[grid_y * self._occupancy_grid.info.width + grid_x])
 
-    def in_bound_points(self, point_type: type[PointT]) -> Iterator[PointT]:
+    def in_bound_points(self) -> Iterator[Point2d]:
         """
         Generate a point in all in bound grids
-
-        Args:
-            point_type: The point type to yield - either Point or Point2d.
 
         Yields:
             World-coordinate points at the centers of all in-bound grid cells.
         """
         for x in range(self._occupancy_grid.info.width):
             for y in range(self._occupancy_grid.info.height):
-                yield self._grid_index_center_to_world(x, y, point_type)
+                yield self._grid_index_center_to_world(x, y)
 
-    def neighbors4(self, point: PointT) -> Iterator[PointT]:
+    def neighbors4(self, point: Point2d) -> Iterator[Point2d]:
         """
         Generate 4-connected neighboring world points for discrete grid search.
 
@@ -127,14 +121,14 @@ class WorldOccupancyGrid:
             point: World-coordinate point whose grid cell is expanded.
 
         Yields:
-            World-coordinate points at the centers of neighboring grid cells, in the same type as `point`.
+            World-coordinate points at the centers of neighboring grid cells.
         """
         x, y = self._world_to_grid_index(point)
 
         for dx, dy in ((1, 0), (0, 1), (0, -1), (-1, 0)):
-            yield self._grid_index_center_to_world(x + dx, y + dy, type(point))
+            yield self._grid_index_center_to_world(x + dx, y + dy)
 
-    def neighbors8(self, point: PointT) -> Iterator[PointT]:
+    def neighbors8(self, point: Point2d) -> Iterator[Point2d]:
         """
         Generate 8-connected neighboring world points for discrete grid search.
 
@@ -145,7 +139,7 @@ class WorldOccupancyGrid:
             point: World-coordinate point whose grid cell is expanded.
 
         Yields:
-            World-coordinate points at the centers of neighboring grid cells, in the same type as `point`.
+            World-coordinate points at the centers of neighboring grid cells.
         """
         x, y = self._world_to_grid_index(point)
 
@@ -153,9 +147,9 @@ class WorldOccupancyGrid:
             for dx in (-1, 0, 1):
                 if dx == 0 and dy == 0:
                     continue
-                yield self._grid_index_center_to_world(x + dx, y + dy, type(point))
+                yield self._grid_index_center_to_world(x + dx, y + dy)
 
-    def neighbors_forward(self, point: PointT) -> Iterator[PointT]:
+    def neighbors_forward(self, point: Point2d) -> Iterator[Point2d]:
         """
         Generate a forward-biased set of neighboring world points.
 
@@ -166,7 +160,7 @@ class WorldOccupancyGrid:
             point: World-coordinate point whose grid cell is expanded.
 
         Yields:
-            World-coordinate points at the centers of selected neighboring cells, in the same type as `point`.
+            World-coordinate points at the centers of selected neighboring cells.
         """
         x, y = self._world_to_grid_index(point)
 
@@ -179,9 +173,9 @@ class WorldOccupancyGrid:
         ]
 
         for dx, dy in candidates:
-            yield self._grid_index_center_to_world(x + dx, y + dy, type(point))
+            yield self._grid_index_center_to_world(x + dx, y + dy)
 
-    def hash_key(self, point: Point | Point2d) -> int:
+    def hash_key(self, point: Point2d) -> int:
         """
         Compute a stable hash key for the grid cell containing a world point.
 
@@ -203,7 +197,7 @@ class WorldOccupancyGrid:
         # cantor pairing (https://en.wikipedia.org/wiki/Pairing_function)
         return (zx + zy) * (zx + zy + 1) // 2 + zy
 
-    def _world_to_grid_index(self, world: Point | Point2d) -> tuple[int, int]:
+    def _world_to_grid_index(self, world: Point2d) -> tuple[int, int]:
         """
         Project a world-coordinate point into discrete grid indices.
 
@@ -213,11 +207,10 @@ class WorldOccupancyGrid:
         Returns:
             (grid_x, grid_y) integer indices corresponding to the grid cell containing the point.
         """
-        p2d = Point2d.from_ros(world) if isinstance(world, Point) else world
-        grid = self._origin.world_to_local(p2d) / self._occupancy_grid.info.resolution
+        grid = self._origin.world_to_local(world) / self._occupancy_grid.info.resolution
         return math.floor(grid.x), math.floor(grid.y)
 
-    def _grid_index_center_to_world(self, grid_x: int, grid_y: int, point_type: type[PointT]) -> PointT:
+    def _grid_index_center_to_world(self, grid_x: int, grid_y: int) -> Point2d:
         """
         Convert a grid cell index to the world-coordinate position of its center.
 
@@ -227,11 +220,9 @@ class WorldOccupancyGrid:
         Args:
             grid_x: Grid index in the +X (forward) direction.
             grid_y: Grid index in the +Y (left) direction.
-            point_type: The point type to return - either Point or Point2d.
 
         Returns:
             World-coordinate point at the center of the specified grid cell.
         """
         grid = Point2d(x=grid_x + 0.5, y=grid_y + 0.5) * self._occupancy_grid.info.resolution
-        p2d = self._origin.local_to_world(grid)
-        return p2d.to_ros() if point_type is Point else p2d
+        return self._origin.local_to_world(grid)


### PR DESCRIPTION
## What has changed
Remove `geometry_msgs.Point`  access of `WorldOccupancyGrid` and require `Point2d` instead. `Point2d` is more correct but it appears that `WorldOccupancyGrid` was written before it existed, so I opted to support both types instead. Now that all math go through `Point2d` we can drop it to avoid needing to deal with overloading / type magic. 

## Testing plan
Passes unit tests. The two consumers (path planning, autonav goal selection) are tested in sim